### PR TITLE
enh: Implements `__instancecheck__` for `DataRefMeta`

### DIFF
--- a/python/xorbits/core/data.py
+++ b/python/xorbits/core/data.py
@@ -152,7 +152,10 @@ class DataRefMeta(type):
             # for subclass like isintance(x, DataFrame),
             # check its data_type if match with cls
             data_type = instance.data_type
-            return data_type == SUB_CLASS_TO_DATA_TYPE[cls]
+            try:
+                return data_type == SUB_CLASS_TO_DATA_TYPE[cls]
+            except KeyError:
+                raise TypeError(f"Unknonw subclass: {cls.__name__}")
 
 
 class DataRef(metaclass=DataRefMeta):

--- a/python/xorbits/core/tests/test_instance_check.py
+++ b/python/xorbits/core/tests/test_instance_check.py
@@ -1,0 +1,60 @@
+# Copyright 2022 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ...core.data import DataRef
+from ...numpy import ndarray
+from ...pandas import DataFrame, Index, Series
+from ...pandas.groupby import DataFrameGroupBy, SeriesGroupBy
+
+
+def test_instance_check(dummy_df, dummy_int_series, dummy_int_2d_array):
+    # DataFrame
+    assert dummy_df.__class__ is DataFrame
+    assert isinstance(dummy_df, DataFrame)
+    assert isinstance(dummy_df, DataRef)
+
+    computed = dummy_df + dummy_df
+    assert computed.__class__ is DataRef
+    assert isinstance(computed, DataFrame)
+
+    # Series
+    assert dummy_int_series.__class__ is Series
+    assert isinstance(dummy_int_series, Series)
+    assert isinstance(dummy_df, DataRef)
+
+    computed = dummy_int_series + dummy_int_series
+    assert computed.__class__ is DataRef
+    assert isinstance(computed, Series)
+
+    # Index
+    assert dummy_df.index.__class__ is DataRef
+    assert isinstance(dummy_df.index, Index)
+
+    # DataFrameGroupBy
+    grouped = dummy_df.groupby("foo")
+    assert grouped.__class__ is DataRef
+    assert isinstance(grouped, DataFrameGroupBy)
+
+    # SeriesGroupBy
+    grouped = dummy_int_series.groupby()
+    assert grouped.__class__ is DataRef
+    assert isinstance(grouped, SeriesGroupBy)
+
+    # tensor
+    assert dummy_int_2d_array.__class__ is DataRef
+    assert isinstance(dummy_int_2d_array, ndarray)
+
+    computed = dummy_int_2d_array + 1
+    assert computed.__class__ is DataRef
+    assert isinstance(computed, ndarray)

--- a/python/xorbits/core/utils/docstring.py
+++ b/python/xorbits/core/utils/docstring.py
@@ -19,7 +19,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Type
 import numpy
 import pandas
 
-from xorbits.core.data import DataType
+from ...core.data import DataType
 
 _DATA_TYPE_TO_DOCSTRING_SRC: Dict[DataType, Tuple[ModuleType, Type]] = {
     DataType.dataframe: (pandas, pandas.DataFrame),

--- a/python/xorbits/core/utils/tests/test_docstring.py
+++ b/python/xorbits/core/utils/tests/test_docstring.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from xorbits.core.utils.docstring import (
+from ....core.utils.docstring import (
     add_arg_disclaimer,
     add_docstring_disclaimer,
     skip_doctest,

--- a/python/xorbits/numpy/core.py
+++ b/python/xorbits/numpy/core.py
@@ -14,10 +14,12 @@
 
 import numpy
 
-from xorbits.core import DataRef
-from xorbits.core.utils.docstring import attach_module_callable_docstring
+from ..core import DataRef, DataType
+from ..core.data import register_cls_to_type
+from ..core.utils.docstring import attach_module_callable_docstring
 
 
+@register_cls_to_type(DataType.tensor)
 class ndarray(DataRef):
     pass
 

--- a/python/xorbits/numpy/lib/index_tricks.py
+++ b/python/xorbits/numpy/lib/index_tricks.py
@@ -13,11 +13,15 @@
 # limitations under the License.
 import numpy
 
-from xorbits.core.adapter import register_converter
-from xorbits.core.utils.docstring import attach_module_callable_docstring
-from xorbits.numpy.mars_adapters.core import MarsGetItemProxy
-
-from ...core.adapter import MarsCClass, MarsMGridClass, MarsOGridClass, MarsRClass
+from ...core.adapter import (
+    MarsCClass,
+    MarsMGridClass,
+    MarsOGridClass,
+    MarsRClass,
+    register_converter,
+)
+from ...core.utils.docstring import attach_module_callable_docstring
+from ...numpy.mars_adapters.core import MarsGetItemProxy
 
 
 @register_converter(from_cls_list=[MarsCClass])

--- a/python/xorbits/numpy/mars_adapters/flatiter.py
+++ b/python/xorbits/numpy/mars_adapters/flatiter.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from xorbits.core.adapter import (
+from ...core.adapter import (
     mars_flatiter,
     register_converter,
     to_mars,

--- a/python/xorbits/numpy/mars_adapters/tests/test_mars_adapters.py
+++ b/python/xorbits/numpy/mars_adapters/tests/test_mars_adapters.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from xorbits.core import DataRef
-
 from .... import numpy as np
+from ....core import DataRef
 
 
 def test_array_creation():

--- a/python/xorbits/pandas/core.py
+++ b/python/xorbits/pandas/core.py
@@ -17,11 +17,13 @@ from pandas.core.accessor import CachedAccessor
 
 from ..core import Data, DataRef, DataType
 from ..core.adapter import MarsDataFrame, MarsIndex, MarsSeries, to_mars
+from ..core.data import register_cls_to_type
 from ..core.utils.docstring import attach_module_callable_docstring
 from .accessors import DatetimeAccessor, StringAccessor
 from .plotting import PlotAccessor
 
 
+@register_cls_to_type(data_type=DataType.dataframe)
 class DataFrame(DataRef):
 
     plot = CachedAccessor("plot", PlotAccessor)
@@ -37,6 +39,7 @@ class DataFrame(DataRef):
 attach_module_callable_docstring(DataFrame, pandas, pandas.DataFrame)
 
 
+@register_cls_to_type(data_type=DataType.series)
 class Series(DataRef):
 
     str = CachedAccessor("str", StringAccessor)
@@ -54,6 +57,7 @@ class Series(DataRef):
 attach_module_callable_docstring(Series, pandas, pandas.Series)
 
 
+@register_cls_to_type(data_type=DataType.index)
 class Index(DataRef):
     def __init__(self, *args, **kwargs):
         data = Data(

--- a/python/xorbits/pandas/groupby.py
+++ b/python/xorbits/pandas/groupby.py
@@ -16,9 +16,11 @@ import pandas
 
 from ..core import Data, DataRef, DataType
 from ..core.adapter import MarsDataFrameGroupBy, MarsSeriesGroupBy, to_mars
+from ..core.data import register_cls_to_type
 from ..core.utils.docstring import attach_module_callable_docstring
 
 
+@register_cls_to_type(DataType.dataframe_groupby)
 class DataFrameGroupBy(DataRef):
     def __init__(self, *args, **kwargs):
         data = Data(
@@ -33,6 +35,7 @@ attach_module_callable_docstring(
 )
 
 
+@register_cls_to_type(data_type=DataType.series_groupby)
 class SeriesGroupBy(DataRef):
     def __init__(self, *args, **kwargs):
         data = Data(

--- a/python/xorbits/pandas/mars_adapters/tests/test_pandas_examples.py
+++ b/python/xorbits/pandas/mars_adapters/tests/test_pandas_examples.py
@@ -19,7 +19,7 @@ from typing import Any, List, Tuple
 
 import pytest
 
-from xorbits import pandas as xpd
+from .... import pandas as xpd
 
 
 def run_docstring(

--- a/python/xorbits/remote/mars_adapters/tests/test_mars_adapters.py
+++ b/python/xorbits/remote/mars_adapters/tests/test_mars_adapters.py
@@ -14,10 +14,9 @@
 
 import re
 
-from xorbits.core import DataRef
-
 from .... import pandas as xpd
 from .... import remote
+from ....core import DataRef
 
 
 def test_spawn(setup):


### PR DESCRIPTION
Implements `__instancecheck__` for `DataRefMeta` to make it works with `isinstance`.

Resolves #61 