### PR TITLE
ENH: make to_numpy an alias of to_tensor

### DIFF
--- a/python/xorbits/pandas/pandas_adapters/core.py
+++ b/python/xorbits/pandas/pandas_adapters/core.py
@@ -190,6 +190,9 @@ def _collect_pandas_dataframe_members():
         ):
             dataframe_members[name] = wrap_pandas_dataframe_method(name)
 
+    # make to_numpy an alias of to_tensor
+    dataframe_members["to_numpy"] = dataframe_members["to_tensor"]
+
 
 def _collect_pandas_module_members() -> Dict[str, Any]:
     from ..mars_adapters.core import MARS_DATAFRAME_CALLABLES

--- a/python/xorbits/pandas/pandas_adapters/tests/test_pandas_adapters.py
+++ b/python/xorbits/pandas/pandas_adapters/tests/test_pandas_adapters.py
@@ -128,3 +128,10 @@ def test_pandas_module_methods(setup):
     assert str(r) == str(expected)
     assert isinstance(r, DataRef)
     pd.testing.assert_frame_equal(r.to_pandas(), expected)
+
+
+def test_to_numpy(setup):
+    df = pd.DataFrame((1, 2, 3))
+    xdf = xpd.DataFrame((1, 2, 3))
+
+    np.testing.assert_array_equal(df.to_numpy(), xdf.to_numpy().to_numpy())


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

Make `DataFrame.to_numpy` an alias of `DataFrame.to_tensor`, so that `DataFrame.to_numpy` will not fall back to pandas.

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass
