### PR TITLE
DOC: Add warnings for methods falling back to pandas

### DIFF
--- a/python/xorbits/core/utils/docstring.py
+++ b/python/xorbits/core/utils/docstring.py
@@ -54,7 +54,7 @@ def add_docstring_disclaimer(
     docstring_src_module: Optional[ModuleType],
     docstring_src_cls: Optional[Callable],
     doc: Optional[str],
-    fallback_warning: Optional[bool] = False,
+    fallback_warning: bool = False,
 ) -> Optional[str]:
     if doc is None:
         return None
@@ -258,7 +258,7 @@ def attach_module_callable_docstring(
     c: Callable,
     docstring_src_module: ModuleType,
     docstring_src: Optional[Callable],
-    fallback_warning: Optional[bool] = False,
+    fallback_warning: bool = False,
 ) -> Callable:
     """
     Attach docstring to functions and constructors.
@@ -282,7 +282,7 @@ def attach_cls_member_docstring(
     data_type: Optional[DataType] = None,
     docstring_src_module: Optional[ModuleType] = None,
     docstring_src_cls: Optional[Type] = None,
-    fallback_warning: Optional[bool] = False,
+    fallback_warning: bool = False,
 ) -> Any:
     """
     Attach docstring to class members.

--- a/python/xorbits/core/utils/docstring.py
+++ b/python/xorbits/core/utils/docstring.py
@@ -65,7 +65,7 @@ def add_docstring_disclaimer(
 
     warning_msg = (
         f"\n\n{base_indentation}.. warning:: This method has not been implemented yet. Xorbits will try to "
-        f"execute it with {docstring_src_module.__name__}. "
+        f"execute it with {docstring_src_module.__name__}."
         if fallback_warning and docstring_src_module
         else "\n"
     )
@@ -77,7 +77,7 @@ def add_docstring_disclaimer(
     ):
         return (
             doc + warning_msg + f"\n{base_indentation}This docstring was copied from "
-            f"{docstring_src_cls.__module__}.{docstring_src_cls.__name__}. "
+            f"{docstring_src_cls.__module__}.{docstring_src_cls.__name__}."
         )
     elif docstring_src_module is not None:
         return (

--- a/python/xorbits/core/utils/docstring.py
+++ b/python/xorbits/core/utils/docstring.py
@@ -54,7 +54,7 @@ def add_docstring_disclaimer(
     docstring_src_module: Optional[ModuleType],
     docstring_src_cls: Optional[Callable],
     doc: Optional[str],
-    fallback_warning: Optional[bool],
+    fallback_warning: Optional[bool] = False,
 ) -> Optional[str]:
     if doc is None:
         return None

--- a/python/xorbits/core/utils/docstring.py
+++ b/python/xorbits/core/utils/docstring.py
@@ -65,9 +65,9 @@ def add_docstring_disclaimer(
 
     warning_msg = (
         f"\n\n{base_indentation}.. warning:: This method has not been implemented yet. Xorbits will try to "
-        f"execute it with pandas. "
-        if fallback_warning
-        else ""
+        f"execute it with {docstring_src_module.__name__}. "
+        if fallback_warning and docstring_src_module
+        else "\n"
     )
 
     if (

--- a/python/xorbits/core/utils/tests/test_docstring.py
+++ b/python/xorbits/core/utils/tests/test_docstring.py
@@ -28,6 +28,19 @@ def test_add_docstring_disclaimer():
         "This docstring was copied from pandas.core.frame.DataFrame."
     )
 
+    assert (
+        add_docstring_disclaimer(pd, pd.from_dummies, "\n\n\n", True)
+        .split("\n")[-2]
+        .endswith(
+            f".. warning:: This method has not been implemented yet. Xorbits will try to "
+            f"execute it with {pd.__name__}."
+        )
+    )
+    assert (
+        add_docstring_disclaimer(pd, pd.DataFrame, "test\n", False)
+        == "test\n\n\nThis docstring was copied from pandas.core.frame.DataFrame."
+    )
+
 
 def test_skip_doctest():
     doc = ">>> a = 0"

--- a/python/xorbits/core/utils/tests/test_docstring.py
+++ b/python/xorbits/core/utils/tests/test_docstring.py
@@ -29,7 +29,7 @@ def test_add_docstring_disclaimer():
     )
 
     assert (
-        add_docstring_disclaimer(pd, pd.from_dummies, "\n\n\n", True)
+        add_docstring_disclaimer(pd, pd.DataFrame, "test\n", True)
         .split("\n")[-2]
         .endswith(
             f".. warning:: This method has not been implemented yet. Xorbits will try to "

--- a/python/xorbits/pandas/pandas_adapters/core.py
+++ b/python/xorbits/pandas/pandas_adapters/core.py
@@ -222,6 +222,7 @@ def _collect_pandas_module_members() -> Dict[str, Any]:
                     is_cls_member=False,
                     docstring_src_module=pd,
                     docstring_src=getattr(pd, name, None),
+                    fallback_warning=True,
                 )
     return module_methods
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #69

Add warning message like this:
<img width="732" alt="image" src="https://user-images.githubusercontent.com/65081722/208020205-df572885-9409-4259-866d-268a4733368d.png">

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
