### PR TITLE
BUG: Set `use_arrow_dtype`'s default to False in TPCH benchmark

### DIFF
--- a/benchmarks/tpch/run_queries.py
+++ b/benchmarks/tpch/run_queries.py
@@ -1081,8 +1081,8 @@ def main():
     )
     parser.add_argument(
         "--use-arrow-dtype",
-        type=bool,
-        default=True,
+        default=False,
+        action="store_true",
         help="Use arrow dtype.",
     )
     parser.add_argument(


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Set `use_arrow_dtype`'s default to False in TPCH benchmark.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass
