### PR TITLE
ENH: Stop executing DataRef when pycharm etc tries to evaluate properties in debug

### DIFF
--- a/python/xorbits/core/data.py
+++ b/python/xorbits/core/data.py
@@ -17,6 +17,8 @@ from enum import Enum
 from itertools import count
 from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Type
 
+from ..utils import safe_repr_str
+
 if TYPE_CHECKING:  # pragma: no cover
     from ..core.adapter import MarsEntity
 
@@ -210,6 +212,7 @@ class DataRef(metaclass=DataRefMeta):
 
                 yield from gen()
 
+    @safe_repr_str
     def __str__(self):
         from .execution import run
 
@@ -220,6 +223,7 @@ class DataRef(metaclass=DataRefMeta):
             run(self)
             return self.data.__str__()
 
+    @safe_repr_str
     def __repr__(self):
         from .execution import run
 

--- a/python/xorbits/tests/mock_pydevd_xml.py
+++ b/python/xorbits/tests/mock_pydevd_xml.py
@@ -1,0 +1,19 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# mock pydevd_xml
+
+
+def var_to_xml(obj):
+    return f"<data>{str(obj)}</data>"

--- a/python/xorbits/tests/test_utils.py
+++ b/python/xorbits/tests/test_utils.py
@@ -1,0 +1,31 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest.mock as mock
+
+from ..core.execution import need_to_execute
+from .mock_pydevd_xml import var_to_xml
+
+
+@mock.patch("xorbits.utils.is_pydev_evaluating_value", side_effect=lambda: True)
+def test_safe_repr_str(setup, dummy_df):
+    df = dummy_df + 1
+    assert "xorbits.core.data.DataRef object" in repr(df)
+    assert "xorbits.core.data.DataRef object" in str(df)
+    assert need_to_execute(df)
+
+
+def test_safe_repr_str_for_mock_pydevd_xml(setup, dummy_df):
+    df = dummy_df + 1
+    assert "xorbits.core.data.DataRef object" in var_to_xml(df)

--- a/python/xorbits/utils.py
+++ b/python/xorbits/utils.py
@@ -12,14 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import traceback
 from typing import Callable
-
-
-def is_debug() -> bool:
-    """Return if the debugger is currently active"""
-    return hasattr(sys, "gettrace") and sys.gettrace() is not None
 
 
 def is_pydev_evaluating_value() -> bool:

--- a/python/xorbits/utils.py
+++ b/python/xorbits/utils.py
@@ -1,0 +1,41 @@
+# Copyright 2022-2023 XProbe Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import traceback
+from typing import Callable
+
+
+def is_debug() -> bool:
+    """Return if the debugger is currently active"""
+    return hasattr(sys, "gettrace") and sys.gettrace() is not None
+
+
+def is_pydev_evaluating_value() -> bool:
+    for frame in traceback.extract_stack():
+        if "pydev" in frame.filename and frame.name == "var_to_xml":
+            return True
+    return False
+
+
+def safe_repr_str(f: Callable):
+    def inn(self, *args, **kwargs):
+        if is_pydev_evaluating_value():
+            # if is evaluating value from pydev, pycharm, etc
+            # skip repr or str
+            return getattr(object, f.__name__)(self)
+        else:
+            return f(self, *args, **kwargs)
+
+    return inn


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
