### PR TITLE
DOC: clarified np vs xnp for numpy vs xorbits.numpy

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,14 +4,14 @@ Thank you for your contribution!
 
 ## What do these changes do?
 
-<!-- Please give a short brief about these changes. -->
+# Changed all instances of 'import numpy as np' to simply 'import numpy'. This is to reduce confusion with np and xnp often being used in the same code and to help improve readability. There was also cases where 'import xorbits.numpy' and and 'from .... import numpy' were aliased as 'np instead of importing as 'xnp'. This is a problem as they were labelled as 'xnp' in other files that numpy and xorbits.numpy. These misslabeled 'np' aliases were corrected to 'xnp' to match other files. All 'xnp' aliases were left as xnp for readability. The more obvious and consistent naming should reduce ambiguity and improve clarity. Additionally, a note was added on line 32 of the 'numpy.rst' file in 'Getting started' to explicitly layout the lack of np and the separation of numpy and xnp
 
 ## Related issue number
 
 <!-- Are there any issues opened that will be resolved by merging this change? -->
-Fixes #xxxx
+Fixes #153
 
 ## Check code requirements
 
-- [ ] tests added / passed (if needed)
-- [ ] Ensure all linting tests pass
+- [X] tests added / passed (if needed)
+- [X] Ensure all linting tests pass

--- a/CI/test_basic_execution.py
+++ b/CI/test_basic_execution.py
@@ -11,13 +11,13 @@ def test_basic_cases():
         warnings.simplefilter("error")
         import xorbits
         import xorbits.pandas as pd
-        import xorbits.numpy as np
+        import xorbits.numpy as xnp
 
     xorbits.init()
     df = pd.DataFrame({'A': [1, 2, 3]})
     assert str(df) == str(pandas.DataFrame({'A': [1, 2, 3]}))
 
-    array = np.ones((2, 2))
+    array = xnp.ones((2, 2))
     assert str(array) == str(numpy.ones((2, 2)))
 
     # make sure web is built

--- a/doc/source/deployment/cloud.rst
+++ b/doc/source/deployment/cloud.rst
@@ -40,8 +40,8 @@ To verify the cluster:
 
 .. code-block:: python
 
-    import xorbits.numpy as np
-    a = np.ones((100, 100), chunk_size=30) * 2 * 1 + 1
-    b = np.ones((100, 100), chunk_size=20) * 2 * 1 + 1
+    import xorbits.numpy as xnp
+    a = xnp.ones((100, 100), chunk_size=30) * 2 * 1 + 1
+    b = xnp.ones((100, 100), chunk_size=20) * 2 * 1 + 1
     c = (a * b * 2 + 1).sum()
     print(c)

--- a/doc/source/deployment/cluster.rst
+++ b/doc/source/deployment/cluster.rst
@@ -154,7 +154,7 @@ On a client which is able to connect to supervisor, you can run the Python code 
 .. code-block:: python
 
     import xorbits
-    import xorbits.numpy as np
+    import xorbits.numpy as xnp
 
     xorbits.init('http://192.168.1.10:7005')
-    print(np.random.rand(100, 100).mean())
+    print(xnp.random.rand(100, 100).mean())

--- a/doc/source/getting_started/numpy.rst
+++ b/doc/source/getting_started/numpy.rst
@@ -16,23 +16,25 @@ function. The type of the resulting array is deduced from the type of the elemen
 
 ::
 
-    >>> import xorbits.numpy as np
-    >>> a = np.array([2, 3, 4])
+    >>> import xorbits.numpy as xnp
+    >>> a = xnp.array([2, 3, 4])
     >>> a
     array([2, 3, 4])
     >>> a.dtype
     dtype('int64')
-    >>> b = np.array([1.2, 3.5, 5.1])
+    >>> b = xnp.array([1.2, 3.5, 5.1])
     >>> b.dtype
     dtype('float64')
 
 In addition, creating an array from existing NumPy ndarray is supported.
 
+
+Note: Due to the fact that xorbits.numpy is often aliased as either 'np' or 'xnp', numpy is not aliased and is only referred to as numpy and xorbits.numpy is only referred to as xnp.
 ::
 
-    >>> import numpy as np
+    >>> import numpy
     >>> import xorbits.numpy as xnp
-    >>> a = np.arange(6)
+    >>> a = numpy.arange(6)
     >>> b = xnp.array(a)
     >>> print(b)
     array([0 1 2 3 4 5])
@@ -42,18 +44,18 @@ rather than providing a single sequence as an argument.
 
 ::
 
-    >>> a = np.array(1, 2, 3, 4)    # WRONG
+    >>> a = numpy.array(1, 2, 3, 4)    # WRONG
     Traceback (most recent call last):
       ...
     TypeError: array() takes from 1 to 2 positional arguments but 4 were given
-    >>> a = np.array([1, 2, 3, 4])  # RIGHT
+    >>> a = numpy.array([1, 2, 3, 4])  # RIGHT
 
 ``array`` transforms sequences of sequences into two-dimensional arrays, sequences of sequences
 of sequences into three-dimensional arrays, and so on.
 
 ::
 
-    >>> b = np.array([(1.5, 2, 3), (4, 5, 6)])
+    >>> b = numpy.array([(1.5, 2, 3), (4, 5, 6)])
     >>> b
     array([[1.5, 2. , 3. ],
            [4. , 5. , 6. ]])
@@ -62,7 +64,7 @@ The type of the array can also be explicitly specified at creation time:
 
 ::
 
-    >>> c = np.array([[1, 2], [3, 4]], dtype=complex)
+    >>> c = numpy.array([[1, 2], [3, 4]], dtype=complex)
     >>> c
     array([[1.+0.j, 2.+0.j],
            [3.+0.j, 4.+0.j]])
@@ -78,11 +80,11 @@ specified via the key word argument ``dtype``.
 
 ::
 
-    >>> np.zeros((3, 4))
+    >>> numpy.zeros((3, 4))
     array([[0., 0., 0., 0.],
            [0., 0., 0., 0.],
            [0., 0., 0., 0.]])
-    >>> np.ones((2, 3, 4), dtype=np.int16)
+    >>> numpy.ones((2, 3, 4), dtype=numpy.int16)
     array([[[1, 1, 1, 1],
             [1, 1, 1, 1],
             [1, 1, 1, 1]],
@@ -90,7 +92,7 @@ specified via the key word argument ``dtype``.
            [[1, 1, 1, 1],
             [1, 1, 1, 1],
             [1, 1, 1, 1]]], dtype=int16)
-    >>> np.empty((2, 3)) #doctest: +SKIP
+    >>> numpy.empty((2, 3)) #doctest: +SKIP
     array([[3.73603959e-262, 6.02658058e-154, 6.55490914e-260],  # may vary
            [5.30498948e-313, 3.14673309e-307, 1.00000000e+000]])
 
@@ -99,9 +101,9 @@ To create sequences of numbers, use ``arange`` function which is analogous to th
 
 ::
 
-    >>> np.arange(10, 30, 5)
+    >>> numpy.arange(10, 30, 5)
     array([10, 15, 20, 25])
-    >>> np.arange(0, 2, 0.3)  # it accepts float arguments
+    >>> numpy.arange(0, 2, 0.3)  # it accepts float arguments
     array([0. , 0.3, 0.6, 0.9, 1.2, 1.5, 1.8])
 
 When ``arange`` is used with floating point arguments, it is generally not possible to predict the
@@ -110,20 +112,20 @@ usually better to use the function ``linspace`` that receives as an argument the
 elements that we want, instead of the step::
 
     >>> from xorbits.numpy import pi
-    >>> np.linspace(0, 2, 9)                   # 9 numbers from 0 to 2
+    >>> numpy.linspace(0, 2, 9)                   # 9 numbers from 0 to 2
     array([0.  , 0.25, 0.5 , 0.75, 1.  , 1.25, 1.5 , 1.75, 2.  ])
-    >>> x = np.linspace(0, 2 * pi, 100)        # useful to evaluate function at lots of points
-    >>> f = np.sin(x)
+    >>> x = numpy.linspace(0, 2 * pi, 100)        # useful to evaluate function at lots of points
+    >>> f = numpy.sin(x)
 
 
 However, the way of loading and saving arrays is quite different. Please see :ref:`io <routines.io>` for
 detailed info. Here's an example of loading an HDF5 file::
 
-    >>> a = np.from_hdf5("t.hdf5", dataset="t")
+    >>> a = numpy.from_hdf5("t.hdf5", dataset="t")
 
 Once an ndarray is created, use ``to_numpy`` to convert it to a local NumPy ndarray::
 
-    >>> a = np.array([1, 2, 3, 4])
+    >>> a = numpy.array([1, 2, 3, 4])
     >>> a.to_numpy()
     array([1, 2, 3, 4])
 
@@ -143,18 +145,18 @@ as lists of matrices.
 
 ::
 
-    >>> a = np.arange(6)                    # 1d array
+    >>> a = numpy.arange(6)                    # 1d array
     >>> print(a)
     [0 1 2 3 4 5]
     >>>
-    >>> b = np.arange(12).reshape(4, 3)     # 2d array
+    >>> b = numpy.arange(12).reshape(4, 3)     # 2d array
     >>> print(b)
     [[ 0  1  2]
      [ 3  4  5]
      [ 6  7  8]
      [ 9 10 11]]
     >>>
-    >>> c = np.arange(24).reshape(2, 3, 4)  # 3d array
+    >>> c = numpy.arange(24).reshape(2, 3, 4)  # 3d array
     >>> print(c)
     [[[ 0  1  2  3]
       [ 4  5  6  7]
@@ -167,10 +169,10 @@ as lists of matrices.
 If an array is too large to be printed, the central part of the array will be automatically skipped
 and only prints the corners::
 
-    >>> print(np.arange(10000))
+    >>> print(numpy.arange(10000))
     [   0    1    2 ... 9997 9998 9999]
     >>>
-    >>> print(np.arange(10000).reshape(100, 100))
+    >>> print(numpy.arange(10000).reshape(100, 100))
     [[   0    1    2 ...   97   98   99]
      [ 100  101  102 ...  197  198  199]
      [ 200  201  202 ...  297  298  299]
@@ -190,8 +192,8 @@ result.
 
 ::
 
-    >>> a = np.array([20, 30, 40, 50])
-    >>> b = np.arange(4)
+    >>> a = numpy.array([20, 30, 40, 50])
+    >>> b = numpy.arange(4)
     >>> b
     array([0, 1, 2, 3])
     >>> c = a - b
@@ -199,7 +201,7 @@ result.
     array([20, 29, 38, 47])
     >>> b**2
     array([0, 1, 4, 9])
-    >>> 10 * np.sin(a)
+    >>> 10 * numpy.sin(a)
     array([ 9.12945251, -9.88031624,  7.4511316 , -2.62374854])
     >>> a < 35
     array([ True,  True, False, False])
@@ -208,9 +210,9 @@ Unlike in many matrix languages, the product operator ``*`` operates elementwise
 :code:`xorbits.numpy` arrays. The matrix product can be performed using the ``@`` operator (in
 python >=3.5) or the ``dot`` function or method::
 
-    >>> A = np.array([[1, 1],
+    >>> A = numpy.array([[1, 1],
     ...               [0, 1]])
-    >>> B = np.array([[2, 0],
+    >>> B = numpy.array([[2, 0],
     ...               [3, 4]])
     >>> A * B     # elementwise product
     array([[2, 0],
@@ -227,7 +229,7 @@ create a new one.
 
 ::
 
-    >>> a = np.ones((2, 3), dtype=int)
+    >>> a = numpy.ones((2, 3), dtype=int)
     >>> b = rg.random((2, 3))
     >>> a *= 3
     >>> a
@@ -243,8 +245,8 @@ more general or precise one (a behavior known as upcasting).
 
 ::
 
-    >>> a = np.ones(3, dtype=np.int32)
-    >>> b = np.linspace(0, pi, 3)
+    >>> a = numpy.ones(3, dtype=numpy.int32)
+    >>> b = numpy.linspace(0, pi, 3)
     >>> b.dtype.name
     'float64'
     >>> c = a + b
@@ -252,7 +254,7 @@ more general or precise one (a behavior known as upcasting).
     array([1.        , 2.57079633, 4.14159265])
     >>> c.dtype.name
     'float64'
-    >>> d = np.exp(c * 1j)
+    >>> d = numpy.exp(c * 1j)
     >>> d
     array([ 0.54030231+0.84147098j, -0.84147098+0.54030231j,
            -0.54030231-0.84147098j])
@@ -264,7 +266,7 @@ as methods of the ``ndarray`` class.
 
 ::
 
-    >>> a = np.random.random((2, 3))
+    >>> a = numpy.random.random((2, 3))
     >>> a
     array([[0.82770259, 0.40919914, 0.54959369],
            [0.02755911, 0.75351311, 0.53814331]])
@@ -279,7 +281,7 @@ By default, these operations apply to the array as though it were a list of numb
 its shape. However, by specifying the ``axis`` parameter you can apply an operation along the
 specified axis of an array::
 
-    >>> b = np.arange(12).reshape(3, 4)
+    >>> b = numpy.arange(12).reshape(3, 4)
     >>> b
     array([[ 0,  1,  2,  3],
            [ 4,  5,  6,  7],
@@ -306,15 +308,15 @@ output.
 
 ::
 
-    >>> B = np.arange(3)
+    >>> B = numpy.arange(3)
     >>> B
     array([0, 1, 2])
-    >>> np.exp(B)
+    >>> numpy.exp(B)
     array([1.        , 2.71828183, 7.3890561 ])
-    >>> np.sqrt(B)
+    >>> numpy.sqrt(B)
     array([0.        , 1.        , 1.41421356])
-    >>> C = np.array([2., -1., 4.])
-    >>> np.add(B, C)
+    >>> C = numpy.array([2., -1., 4.])
+    >>> numpy.add(B, C)
     array([2., 0., 6.])
 
 .. _quickstart.indexing-slicing-and-iterating:
@@ -329,7 +331,7 @@ and other Python sequences.
 
 ::
 
-    >>> a = np.arange(10)**3
+    >>> a = numpy.arange(10)**3
     >>> a
     array([  0,   1,   8,  27,  64, 125, 216, 343, 512, 729])
     >>> a[2]
@@ -364,7 +366,7 @@ are given in a tuple separated by commas::
     >>> def f(x, y):
     ...     return 10 * x + y
     ...
-    >>> b = np.arange(12).reshape(3, 4)
+    >>> b = numpy.arange(12).reshape(3, 4)
     >>> b
     array([[ 0,  1,  2,  3],
            [ 4,  5,  6,  7],
@@ -402,7 +404,7 @@ axes, then
 
 ::
 
-    >>> c = np.array([[[  0,  1,  2],  # a 3D array (two stacked 2D arrays)
+    >>> c = numpy.array([[[  0,  1,  2],  # a 3D array (two stacked 2D arrays)
     ...                [ 10, 12, 13]],
     ...               [[100, 101, 102],
     ...                [110, 112, 113]]])
@@ -453,7 +455,7 @@ Changing the shape of an array
 
 An array has a shape given by the number of elements along each axis::
 
-    >>> a = np.floor(10 * np.random.random((3, 4)))
+    >>> a = numpy.floor(10 * numpy.random.random((3, 4)))
     >>> a
     array([[6., 9., 5., 2.],
            [4., 9., 8., 9.],
@@ -506,20 +508,20 @@ Stacking together different arrays
 
 Several arrays can be stacked together along different axes::
 
-    >>> a = np.floor(10 * np.random.random((2, 2)))
+    >>> a = numpy.floor(10 * numpy.random.random((2, 2)))
     >>> a
     array([[9., 7.],
            [5., 2.]])
-    >>> b = np.floor(10 * np.random.random((2, 2)))
+    >>> b = numpy.floor(10 * numpy.random.random((2, 2)))
     >>> b
     array([[1., 9.],
            [5., 1.]])
-    >>> np.vstack((a, b))
+    >>> numpy.vstack((a, b))
     array([[9., 7.],
            [5., 2.],
            [1., 9.],
            [5., 1.]])
-    >>> np.hstack((a, b))
+    >>> numpy.hstack((a, b))
     array([[9., 7., 1., 9.],
            [5., 2., 5., 1.]])
 
@@ -527,32 +529,32 @@ The function `column_stack` stacks 1D arrays as columns into a 2D array. It is e
 `hstack` only for 2D arrays::
 
     >>> from xorbits.numpy import newaxis
-    >>> np.column_stack((a, b))  # with 2D arrays
+    >>> numpy.column_stack((a, b))  # with 2D arrays
     array([[9., 7., 1., 9.],
            [5., 2., 5., 1.]])
-    >>> a = np.array([4., 2.])
-    >>> b = np.array([3., 8.])
-    >>> np.column_stack((a, b))  # returns a 2D array
+    >>> a = numpy.array([4., 2.])
+    >>> b = numpy.array([3., 8.])
+    >>> numpy.column_stack((a, b))  # returns a 2D array
     array([[4., 3.],
            [2., 8.]])
-    >>> np.hstack((a, b))        # the result is different
+    >>> numpy.hstack((a, b))        # the result is different
     array([4., 2., 3., 8.])
     >>> a[:, newaxis]  # view `a` as a 2D column vector
     array([[4.],
            [2.]])
-    >>> np.column_stack((a[:, newaxis], b[:, newaxis]))
+    >>> numpy.column_stack((a[:, newaxis], b[:, newaxis]))
     array([[4., 3.],
            [2., 8.]])
-    >>> np.hstack((a[:, newaxis], b[:, newaxis]))  # the result is the same
+    >>> numpy.hstack((a[:, newaxis], b[:, newaxis]))  # the result is the same
     array([[4., 3.],
            [2., 8.]])
 
 On the other hand, the function `row_stack` is equivalent to `vstack` for any input arrays. In
 fact, `row_stack` is an alias for `vstack`::
 
-    >>> np.column_stack is np.hstack
+    >>> numpy.column_stack is numpy.hstack
     False
-    >>> np.row_stack is np.vstack
+    >>> numpy.row_stack is numpy.vstack
     True
 
 In general, for arrays with more than two dimensions, `hstack` stacks along their second axes,
@@ -564,7 +566,7 @@ the number of the axis along which the concatenation should happen.
     In complex cases, `r_` and `c_` are useful for creating arrays by stacking numbers along one axis.
     They allow the use of range literals ``:``. ::
 
-           >>> np.r_[1:4, 0, 4]
+           >>> numpy.r_[1:4, 0, 4]
            array([1, 2, 3, 0, 4])
 
     When used with arrays as arguments, `r_` and `c_` are similar to `vstack` and `hstack` in their
@@ -579,18 +581,18 @@ array along its horizontal axis, either by specifying the number of
 equally shaped arrays to return, or by specifying the columns after
 which the division should occur::
 
-    >>> a = np.floor(10 * rg.random((2, 12)))
+    >>> a = numpy.floor(10 * rg.random((2, 12)))
     >>> a
     array([[6., 7., 6., 9., 0., 5., 4., 0., 6., 8., 5., 2.],
            [8., 5., 5., 7., 1., 8., 6., 7., 1., 8., 1., 0.]])
     >>> # Split `a` into 3
-    >>> np.hsplit(a, 3)
+    >>> numpy.hsplit(a, 3)
     [array([[6., 7., 6., 9.],
            [8., 5., 5., 7.]]), array([[0., 5., 4., 0.],
            [1., 8., 6., 7.]]), array([[6., 8., 5., 2.],
            [1., 8., 1., 0.]])]
     >>> # Split `a` after the third and the fourth column
-    >>> np.hsplit(a, (3, 4))
+    >>> numpy.hsplit(a, (3, 4))
     [array([[6., 7., 6.],
            [8., 5., 5.]]), array([[9.],
            [7.]]), array([[0., 5., 4., 0., 6., 8., 5., 2.],

--- a/doc/source/getting_started/pandas.rst
+++ b/doc/source/getting_started/pandas.rst
@@ -11,7 +11,7 @@ Customarily, we import and init as follows:
 .. ipython:: python
 
    import xorbits
-   import xorbits.numpy as np
+   import xorbits.numpy as xnp
    import xorbits.pandas as pd
    xorbits.init()
 
@@ -23,7 +23,7 @@ Creating a :class:`Series` by passing a list of values, letting it create a defa
 .. ipython:: python
    :okwarning:
 
-   s = pd.Series([1, 3, 5, np.nan, 6, 8])
+   s = pd.Series([1, 3, 5, xnp.nan, 6, 8])
    s
 
 Creating a :class:`DataFrame` by passing an array, with a datetime index and labeled columns:
@@ -32,7 +32,7 @@ Creating a :class:`DataFrame` by passing an array, with a datetime index and lab
 
    dates = pd.date_range('20130101', periods=6)
    dates
-   df = pd.DataFrame(np.random.randn(6, 4), index=dates, columns=list('ABCD'))
+   df = pd.DataFrame(xnp.random.randn(6, 4), index=dates, columns=list('ABCD'))
    df
 
 Creating a :class:`DataFrame` by passing a dict of objects that can be converted to series-like.
@@ -42,7 +42,7 @@ Creating a :class:`DataFrame` by passing a dict of objects that can be converted
    df2 = pd.DataFrame({'A': 1.,
                        'B': pd.Timestamp('20130102'),
                        'C': pd.Series(1, index=list(range(4)), dtype='float32'),
-                       'D': np.array([3] * 4, dtype='int32'),
+                       'D': xnp.array([3] * 4, dtype='int32'),
                        'E': 'foo'})
    df2
 
@@ -271,7 +271,7 @@ Operating with objects that have different dimensionality and need alignment. In
 
 .. ipython:: python
 
-   s = pd.Series([1, 3, 5, np.nan, 6, 8], index=dates).shift(2)
+   s = pd.Series([1, 3, 5, xnp.nan, 6, 8], index=dates).shift(2)
    s
    df.sub(s, axis='index')
 
@@ -296,7 +296,7 @@ some cases always uses them).
 
 .. ipython:: python
 
-   s = pd.Series(['A', 'B', 'C', 'Aaba', 'Baca', np.nan, 'CABA', 'dog', 'cat'])
+   s = pd.Series(['A', 'B', 'C', 'Aaba', 'Baca', xnp.nan, 'CABA', 'dog', 'cat'])
    s.str.lower()
 
 Merge
@@ -314,7 +314,7 @@ Concatenating :code:`xorbits.pandas` objects together with :func:`concat`:
 
 .. ipython:: python
 
-   df = pd.DataFrame(np.random.randn(10, 4))
+   df = pd.DataFrame(xnp.random.randn(10, 4))
    df
 
    # break it into pieces
@@ -368,8 +368,8 @@ following steps:
                             'foo', 'bar', 'foo', 'foo'],
                       'B': ['one', 'one', 'two', 'three',
                             'two', 'two', 'one', 'three'],
-                      'C': np.random.randn(8),
-                      'D': np.random.randn(8)})
+                      'C': xnp.random.randn(8),
+                      'D': xnp.random.randn(8)})
    df
 
 Grouping and then applying the :meth:`~xorbits.pandas.groupby.DataFrameGroupBy.sum` function to
@@ -399,7 +399,7 @@ We use the standard convention for referencing the matplotlib API:
 
 .. ipython:: python
 
-   ts = pd.Series(np.random.randn(1000),
+   ts = pd.Series(xnp.random.randn(1000),
                   index=pd.date_range('1/1/2000', periods=1000))
    ts = ts.cumsum()
 
@@ -411,7 +411,7 @@ of the columns with labels:
 
 .. ipython:: python
 
-   df = pd.DataFrame(np.random.randn(1000, 4), index=ts.index,
+   df = pd.DataFrame(xnp.random.randn(1000, 4), index=ts.index,
                      columns=['A', 'B', 'C', 'D'])
    df = df.cumsum()
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -20,7 +20,7 @@ import sys
 import warnings
 from sysconfig import get_config_vars
 
-import numpy as np
+import numpy
 from Cython.Build import cythonize
 from pkg_resources import parse_version
 from setuptools import Command, Extension, setup
@@ -114,7 +114,7 @@ def _discover_pyx():
             exts[mod_name] = Extension(
                 mod_name,
                 [full_fn] + source,
-                include_dirs=[np.get_include()] + include_dirs,
+                include_dirs=[numpy.get_include()] + include_dirs,
                 **cy_extension_kw,
             )
     return exts

--- a/python/xorbits/conftest.py
+++ b/python/xorbits/conftest.py
@@ -14,7 +14,7 @@
 
 import pytest
 
-from . import numpy as np
+from . import numpy
 from . import pandas as pd
 from ._mars.config import option_context
 from ._mars.deploy.oscar.session import clear_default_session
@@ -24,7 +24,7 @@ from .tests.core import init_test
 
 @pytest.fixture
 def doctest_namespace():
-    return {"pd": pd, "np": np}
+    return {"pd": pd, "numpy": numpy}
 
 
 @pytest.fixture
@@ -49,12 +49,12 @@ def dummy_dt_series():
 
 @pytest.fixture
 def dummy_int_1d_array():
-    return np.array([0, 1, 2])
+    return numpy.array([0, 1, 2])
 
 
 @pytest.fixture
 def dummy_int_2d_array():
-    return np.arange(9).reshape(3, 3)
+    return numpy.arange(9).reshape(3, 3)
 
 
 @pytest.fixture(scope="package")

--- a/python/xorbits/core/tests/test_adapter.py
+++ b/python/xorbits/core/tests/test_adapter.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
+import numpy
 import pandas as pd
 import pytest
 
@@ -179,6 +179,6 @@ def test_iter(setup, dummy_df, dummy_str_series, dummy_int_1d_array):
     for r, expected in zip(dummy_df.index, expected_index):
         assert r == expected
 
-    np_array = np.array([0, 1, 2]) + 1
-    for r, expected in zip(dummy_int_1d_array + 1, np_array):
+    numpy_array = numpy.array([0, 1, 2]) + 1
+    for r, expected in zip(dummy_int_1d_array + 1, numpy_array):
         assert r.to_numpy() == expected

--- a/python/xorbits/deploy/kubernetes/tests/test_kubernetes.py
+++ b/python/xorbits/deploy/kubernetes/tests/test_kubernetes.py
@@ -22,7 +22,7 @@ import uuid
 from contextlib import contextmanager
 from distutils.spawn import find_executable
 
-import numpy as np
+import numpy
 import pytest
 
 from .... import numpy as xnp
@@ -198,5 +198,5 @@ def test_run_in_kubernetes():
         c = (a * b * 2 + 1).sum()
         print(c)
 
-        expected = (np.ones(a.shape) * 2 * 1 + 1) ** 2 * 2 + 1
-        np.testing.assert_array_equal(c.to_numpy(), expected.sum())
+        expected = (numpy.ones(a.shape) * 2 * 1 + 1) ** 2 * 2 + 1
+        numpy.testing.assert_array_equal(c.to_numpy(), expected.sum())

--- a/python/xorbits/numpy/lib/tests/test_index_tricks.py
+++ b/python/xorbits/numpy/lib/tests/test_index_tricks.py
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
+import numpy
 
 from .... import numpy as xnp
 from ..index_tricks import CClass, MGridClass, OGridClass, RClass
 
 
 def test_ogrid(setup):
-    np.testing.assert_array_equal(np.ogrid[-1:1:5j], xnp.ogrid[-1:1:5j].to_numpy())
+    numpy.testing.assert_array_equal(numpy.ogrid[-1:1:5j], xnp.ogrid[-1:1:5j].to_numpy())
 
 
 def test_ogrid_docstring():
@@ -39,7 +39,7 @@ def test_ogrid_docstring():
 
 
 def test_mgrid(setup):
-    np.testing.assert_array_equal(np.mgrid[0:5, 0:5], xnp.mgrid[0:5, 0:5].to_numpy())
+    numpy.testing.assert_array_equal(numpy.mgrid[0:5, 0:5], xnp.mgrid[0:5, 0:5].to_numpy())
 
 
 def test_mgrid_docstring():
@@ -59,8 +59,8 @@ def test_mgrid_docstring():
 
 
 def test_c_(setup):
-    np.testing.assert_array_equal(
-        np.c_[np.array([1, 2, 3]), np.array([4, 5, 6])],
+    numpy.testing.assert_array_equal(
+        numpy.c_[numpy.array([1, 2, 3]), numpy.array([4, 5, 6])],
         xnp.c_[xnp.array([1, 2, 3]), xnp.array([4, 5, 6])].to_numpy(),
     )
 
@@ -82,8 +82,8 @@ def test_c__docstring():
 
 
 def test_r_(setup):
-    np.testing.assert_array_equal(
-        np.r_["0,2,0", [1, 2, 3], [4, 5, 6]],
+    numpy.testing.assert_array_equal(
+        numpy.r_["0,2,0", [1, 2, 3], [4, 5, 6]],
         xnp.r_["0,2,0", [1, 2, 3], [4, 5, 6]].to_numpy(),
     )
 

--- a/python/xorbits/numpy/mars_adapters/tests/test_mars_adapters.py
+++ b/python/xorbits/numpy/mars_adapters/tests/test_mars_adapters.py
@@ -12,24 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .... import numpy as np
+from .... import numpy
 from ....core import DataRef
 
 
 def test_array_creation():
     # 1-d array creation.
-    assert isinstance(np.arange(10), DataRef)
+    assert isinstance(numpy.arange(10), DataRef)
     # 2-d array creation.
-    assert isinstance(np.eye(3), DataRef)
+    assert isinstance(numpy.eye(3), DataRef)
     # n-d array creation.
-    assert isinstance(np.zeros((2, 3)), DataRef)
+    assert isinstance(numpy.zeros((2, 3)), DataRef)
 
 
 def test_indexing(dummy_int_1d_array):
     # test magic method __getitem__.
     assert isinstance(dummy_int_1d_array[0], DataRef)
     assert isinstance(dummy_int_1d_array[1:], DataRef)
-    assert isinstance(dummy_int_1d_array[np.array([1, 2])], DataRef)
+    assert isinstance(dummy_int_1d_array[numpy.array([1, 2])], DataRef)
 
 
 def test_arithmetic_op(dummy_int_1d_array):
@@ -50,20 +50,20 @@ def test_comparison_op(dummy_int_1d_array):
 
 
 def test_fft(dummy_int_1d_array):
-    assert isinstance(np.fft.fft(dummy_int_1d_array), DataRef)
+    assert isinstance(numpy.fft.fft(dummy_int_1d_array), DataRef)
 
 
 def test_linalg(dummy_int_2d_array):
-    for a in np.linalg.svd(dummy_int_2d_array):
+    for a in numpy.linalg.svd(dummy_int_2d_array):
         assert isinstance(a, DataRef)
 
 
 def test_random():
-    assert isinstance(np.random.standard_normal(10), DataRef)
+    assert isinstance(numpy.random.standard_normal(10), DataRef)
 
 
 def test_objects():
-    assert isinstance(np.c_[np.array([1, 2, 3]), np.array([4, 5, 6])], DataRef)
+    assert isinstance(numpy.c_[numpy.array([1, 2, 3]), numpy.array([4, 5, 6])], DataRef)
 
 
 def test_flatiter(dummy_int_1d_array):

--- a/python/xorbits/pandas/mars_adapters/tests/test_user_defined_functions.py
+++ b/python/xorbits/pandas/mars_adapters/tests/test_user_defined_functions.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import numpy as np
+import numpy
 import pandas as pd
 
 from .... import pandas as xpd
@@ -84,7 +84,7 @@ def test_dataframe_transform(setup):
 
 
 def test_dataframe_map_chunk(setup):
-    df = pd.DataFrame(np.random.rand(10, 5), columns=[f"col{i}" for i in range(5)])
+    df = pd.DataFrame(numpy.random.rand(10, 5), columns=[f"col{i}" for i in range(5)])
     xdf = xpd.DataFrame(df, chunk_size=(5, 3))
 
     # infer failed
@@ -106,7 +106,7 @@ def test_dataframe_map_chunk(setup):
 
 
 def test_dataframe_cartesian_chunk(setup):
-    rs = np.random.RandomState(0)
+    rs = numpy.random.RandomState(0)
     raw1 = pd.DataFrame({"a": range(10), "b": rs.rand(10)})
     raw2 = pd.DataFrame(
         {"c": rs.randint(3, size=10), "d": rs.rand(10), "e": rs.rand(10)}

--- a/python/xorbits/pandas/pandas_adapters/tests/test_pandas_adapters.py
+++ b/python/xorbits/pandas/pandas_adapters/tests/test_pandas_adapters.py
@@ -15,7 +15,7 @@
 import os
 import tempfile
 
-import numpy as np
+import numpy
 import pandas as pd
 import pytest
 
@@ -149,7 +149,7 @@ def test_pandas_dataframe_methods(setup):
     expected = raw.median(numeric_only=True).sum()
     assert str(r2) == str(expected)
     assert isinstance(r2, DataRef)
-    np.testing.assert_approx_equal(r2.fetch(), expected)
+    numpy.testing.assert_approx_equal(r2.fetch(), expected)
 
     # output is not series or dataframe
     df = xpd.DataFrame(raw)
@@ -261,7 +261,7 @@ def test_pandas_series_methods(setup):
     assert s.argmax() == r.to_object()
 
     # output is a series and type inference succeed.
-    a = pd.Series([1, 1, 1, np.nan], index=["a", "b", "c", "d"])
+    a = pd.Series([1, 1, 1, numpy.nan], index=["a", "b", "c", "d"])
     xa = xpd.Series(a)
     with pytest.warns(Warning) as w:
         r = xa.divide(10, fill_value=0)
@@ -270,7 +270,7 @@ def test_pandas_series_methods(setup):
     pd.testing.assert_series_equal(a.divide(10, fill_value=0), r.to_pandas())
 
     # multi chunks.
-    s = pd.Series(np.random.randn(12))
+    s = pd.Series(numpy.random.randn(12))
     xs = xpd.Series(s, chunk_size=4)
     with pytest.warns(Warning) as w:
         r = xs.divide(10)
@@ -280,7 +280,7 @@ def test_pandas_series_methods(setup):
 
     # divide by another series.
     # TODO: TypeError: cannot pickle 'weakref' object
-    # b = pd.Series([1, np.nan, 1, np.nan], index=['a', 'b', 'd', 'e'])
+    # b = pd.Series([1, numpy.nan, 1, numpy.nan], index=['a', 'b', 'd', 'e'])
     # xb = xpd.Series(b)
     # with pytest.warns(Warning) as w:
     #     r = xa.divide(xb, fill_value=0)
@@ -301,7 +301,7 @@ def test_pandas_series_methods(setup):
 
     # asof.
     # TODO: AssertionError: shape in metadata (4,) is not consistent with real shape (2,).
-    # s = pd.Series([1, 2, np.nan, 4], index=[10, 20, 30, 40])
+    # s = pd.Series([1, 2, numpy.nan, 4], index=[10, 20, 30, 40])
     # xs = xpd.Series(s)
     # assert s.asof(20) == xs.asof(20).to_object()
     # pd.testing.assert_series_equal(s.asof([5, 20]), xs.asof([5, 20]).to_pandas())
@@ -389,7 +389,7 @@ def test_pandas_index_methods(setup):
     assert i.argmax() == r.to_object()
 
     # output is an array.
-    np.testing.assert_array_equal(i.notnull(), xi.notnull().to_object())
+    numpy.testing.assert_array_equal(i.notnull(), xi.notnull().to_object())
 
     # TODO: TypeError: Input must be Index or array-like
     # i1 = pd.Index([2, 1, 3, 4])
@@ -449,15 +449,15 @@ def test_pandas_module_methods(setup):
 def test_to_numpy(setup):
     df = pd.DataFrame((1, 2, 3))
     xdf = xpd.DataFrame((1, 2, 3))
-    np.testing.assert_array_equal(df.to_numpy(), xdf.to_numpy().to_numpy())
+    numpy.testing.assert_array_equal(df.to_numpy(), xdf.to_numpy().to_numpy())
 
     s = pd.Series((1, 2, 3))
     xs = xpd.Series(s)
-    np.testing.assert_array_equal(s.to_numpy(), xs.to_numpy().to_numpy())
+    numpy.testing.assert_array_equal(s.to_numpy(), xs.to_numpy().to_numpy())
 
     i = s.index
     xi = xs.index
-    np.testing.assert_array_equal(i.to_numpy(), xi.to_numpy().to_numpy())
+    numpy.testing.assert_array_equal(i.to_numpy(), xi.to_numpy().to_numpy())
 
 
 def test_docstring():

--- a/python/xorbits/pandas/tests/test_accessors.py
+++ b/python/xorbits/pandas/tests/test_accessors.py
@@ -33,11 +33,11 @@ def test_str_accessor(setup):
 
 
 def test_dt_accessor(setup):
-    import numpy as np
+    import numpy
 
     # xs being a xorbits.pandas.core.Series instance
-    a = np.arange(
-        np.datetime64("2000-01-01"), np.datetime64("2000-01-03"), dtype=np.datetime64
+    a = numpy.arange(
+        numpy.datetime64("2000-01-01"), numpy.datetime64("2000-01-03"), dtype=numpy.datetime64
     )
     s = pd.Series(a)
     xs = xpd.Series(a)

--- a/python/xorbits/pandas/tests/test_window.py
+++ b/python/xorbits/pandas/tests/test_window.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import numpy as np
+import numpy
 import pandas as pd
 import pytest
 
@@ -28,7 +28,7 @@ def test_rolling(setup):
 
 @pytest.mark.skip("Incompatible behavior")
 def test_ewm(setup):
-    df = pd.DataFrame({"B": [0, 1, 2, np.nan, 4]})
+    df = pd.DataFrame({"B": [0, 1, 2, numpy.nan, 4]})
     xdf = xpd.DataFrame(df)
     #           B
     # 0  0.000000
@@ -50,7 +50,7 @@ def test_ewm(setup):
 
 @pytest.mark.skip("Incompatible behavior")
 def test_expanding(setup):
-    df = pd.DataFrame({"B": [0, 1, 2, np.nan, 4]})
+    df = pd.DataFrame({"B": [0, 1, 2, numpy.nan, 4]})
     xdf = xpd.DataFrame(df)
     expected = df.expanding(1).sum()
     actual = xdf.expanding(1).sum()

--- a/python/xorbits/remote/mars_adapters/core.py
+++ b/python/xorbits/remote/mars_adapters/core.py
@@ -95,9 +95,9 @@ def spawn(
 
     Xorbits objects can also be used in spawned functions.
 
-    >>> import xorbits.numpy as np
+    >>> import xorbits.numpy as xnp
     >>> def driver2():
-    ...     t = np.ones((10, 10))
+    ...     t = xnp.ones((10, 10))
     ...     return t.sum().to_numpy()
     >>> xr.spawn(driver2).to_object()
     100.0


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

Changed all instances of 'import numpy as np' to simply 'import numpy'. This is to reduce confusion with np and xnp often being used in the same code and to help improve readability. There was also cases where 'import xorbits.numpy' and and 'from .... import numpy' were aliased as 'np instead of importing as 'xnp'. This is a problem as they were labelled as 'xnp' in other files that numpy and xorbits.numpy. These misslabeled 'np' aliases were corrected to 'xnp' to match other files. All 'xnp' aliases were left as xnp for readability. The more obvious and consistent naming should reduce ambiguity and improve clarity. Additionally, a note was added on line 32 of the 'numpy.rst' file in 'Getting started' to explicitly layout the lack of np and the separation of numpy and xnp.

p.s. This is my first time committing to another person's Github project, so any advice/critique would greatly be appreciated. Hopefully I was able to help.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #153 

## Check code requirements

- [x ] tests added / passed (if needed)
- [x ] Ensure all linting tests pass
