### PR TITLE
ENH: execute refs in user ns eagerly

### DIFF
--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -53,7 +53,7 @@ console_scripts =
 [options.extras_require]
 dev =
     cython>=0.29
-    ipython>=8.5.0
+    ipython>=6.5.0
     pytest>=3.5.0
     pytest-cov>=2.5.0
     pytest-timeout>=1.2.0

--- a/python/setup.cfg
+++ b/python/setup.cfg
@@ -53,6 +53,7 @@ console_scripts =
 [options.extras_require]
 dev =
     cython>=0.29
+    ipython>=8.5.0
     pytest>=3.5.0
     pytest-cov>=2.5.0
     pytest-timeout>=1.2.0

--- a/python/xorbits/core/execution.py
+++ b/python/xorbits/core/execution.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import builtins
 from typing import List, Tuple, Union
 
 from .adapter import MarsEntity, mars_execute
@@ -37,13 +38,15 @@ def run(obj: Union[DataRef, List[DataRef], Tuple[DataRef]], **kwargs) -> None:
     obj : DataRef or collection of DataRefs
         DataRef or collection of DataRefs to execute.
     """
+    refs = set(_collect_user_ns_refs())
+
     if isinstance(obj, DataRef):
-        if need_to_execute(obj):
-            mars_execute(_get_mars_entity(obj), **kwargs)
+        refs.add(obj)
     else:
-        refs_to_execute = [_get_mars_entity(ref) for ref in obj if need_to_execute(ref)]
-        if refs_to_execute:
-            mars_execute(refs_to_execute, **kwargs)
+        refs.union(set(obj))
+
+    mars_tileables = [_get_mars_entity(ref) for ref in refs if need_to_execute(ref)]
+    mars_execute(mars_tileables, **kwargs)
 
 
 def need_to_execute(ref: DataRef):
@@ -51,4 +54,27 @@ def need_to_execute(ref: DataRef):
     return (
         hasattr(mars_entity, "_executed_sessions")
         and len(getattr(mars_entity, "_executed_sessions")) == 0
+    )
+
+
+def _collect_user_ns_refs():
+    if not _is_interactive() or not _is_ipython_available():
+        print("not in interactive env or ipython is not available")
+        return []
+
+    ipython = getattr(builtins, "get_ipython")()
+    return [v for k, v in ipython.user_ns.items() if isinstance(v, DataRef)]
+
+
+def _is_interactive():
+    import sys
+
+    # See: https://stackoverflow.com/a/64523765/7098025
+    return hasattr(sys, "ps1")
+
+
+def _is_ipython_available():
+    return (
+        hasattr(builtins, "get_ipython")
+        and getattr(builtins, "get_ipython", None) is not None
     )

--- a/python/xorbits/core/execution.py
+++ b/python/xorbits/core/execution.py
@@ -56,7 +56,8 @@ def run(obj: DataRef | list[DataRef] | tuple[DataRef], **kwargs) -> None:
         for ref in refs_to_execute.values()
         if need_to_execute(ref)
     ]
-    mars_execute(mars_tileables, **kwargs)
+    if mars_tileables:
+        mars_execute(mars_tileables, **kwargs)
 
 
 def need_to_execute(ref: DataRef) -> bool:

--- a/python/xorbits/core/tests/test_execution.py
+++ b/python/xorbits/core/tests/test_execution.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
 from ...pandas import get_dummies
 from ..execution import need_to_execute, run
 
@@ -114,3 +116,25 @@ def test_manual_execution(setup, dummy_int_series):
     assert all([need_to_execute(ref) for ref in series_to_execute])
     run(series_to_execute)
     assert not any([need_to_execute(ref) for ref in series_to_execute])
+
+
+@pytest.fixture()
+def ip():
+    from IPython.testing.globalipapp import start_ipython
+
+    yield start_ipython()
+
+
+def test_interactive_execution(setup, ip):
+    ip.run_cell(raw_cell="import xorbits")
+    ip.run_cell(raw_cell="import xorbits.pandas as pd")
+
+    r = ip.run_cell(raw_cell="xorbits.core.execution._is_interactive()")
+    assert r.result
+    r = ip.run_cell(raw_cell="xorbits.core.execution._is_ipython_available()")
+    assert r.result
+
+    ip.run_cell(raw_cell="df = pd.DataFrame({'foo': [1, 2, 3]})")
+    ip.run_cell(raw_cell="xorbits.run(df + 1)")
+    r = ip.run_cell(raw_cell="xorbits.core.execution.need_to_execute(df)")
+    assert not r.result


### PR DESCRIPTION
## What do these changes do?
In interactive env, execute variables in user namespace eagerly to avoid duplicated computation.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Resolves #162 

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass
