### PR TITLE
ENH: Support `read_csv` with passing `skiprows`

### DIFF
--- a/python/xorbits/_mars/dataframe/datasource/read_csv.py
+++ b/python/xorbits/_mars/dataframe/datasource/read_csv.py
@@ -77,11 +77,11 @@ def _find_hdfs_start_end(f, offset, size):
     return start, end
 
 
-def _find_chunk_start_end(f, offset, size, is_first=False):
+def _find_chunk_start_end(f, offset, size, is_first):
     if NativeFile is not None and isinstance(f, NativeFile):
         return _find_hdfs_start_end(f, offset, size)
     f.seek(offset)
-    if is_first:
+    if is_first or offset == 0:
         start = offset
     else:
         f.readline()

--- a/python/xorbits/_mars/dataframe/datasource/read_csv.py
+++ b/python/xorbits/_mars/dataframe/datasource/read_csv.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 from io import BytesIO
-from typing import Dict, List, Tuple, Union
+from typing import Any, Dict, List, Tuple, Union
 from urllib.parse import urlparse
 
 import numpy as np
@@ -51,7 +51,7 @@ from .core import (
 cudf = lazy_import("cudf")
 
 
-def _find_delimiter(f, block_size=2**16):
+def _find_delimiter(f: Any, block_size: int = 2**16):
     delimiter = b"\n"
     if f.tell() == 0:
         return 0
@@ -63,7 +63,7 @@ def _find_delimiter(f, block_size=2**16):
             return f.tell() - len(b) + b.index(delimiter) + 1
 
 
-def _find_hdfs_start_end(f, offset, size):
+def _find_hdfs_start_end(f: Any, offset: int, size: int):
     # As pyarrow doesn't support `readline` operation (https://github.com/apache/arrow/issues/3838),
     # we need to find the start and end of file block manually.
 
@@ -77,7 +77,7 @@ def _find_hdfs_start_end(f, offset, size):
     return start, end
 
 
-def _find_chunk_start_end(f, offset, size, is_first):
+def _find_chunk_start_end(f: Any, offset: int, size: int, is_first: bool):
     if NativeFile is not None and isinstance(f, NativeFile):
         return _find_hdfs_start_end(f, offset, size)
     f.seek(offset)

--- a/python/xorbits/_mars/dataframe/datasource/read_csv.py
+++ b/python/xorbits/_mars/dataframe/datasource/read_csv.py
@@ -81,7 +81,7 @@ def _find_chunk_start_end(f, offset, size, is_first):
     if NativeFile is not None and isinstance(f, NativeFile):
         return _find_hdfs_start_end(f, offset, size)
     f.seek(offset)
-    if is_first or offset == 0:
+    if is_first:
         start = offset
     else:
         f.readline()
@@ -255,7 +255,7 @@ class DataFrameReadCSV(
                 # convert to Series, if usecols is a scalar
                 df = df[op.usecols]
         else:
-            if out_df.index[0] == 0:
+            if out_df.index[0] == 0 or start == 0:
                 # The first chunk contains header
                 # As we specify names and dtype, we need to skip header rows
                 csv_kwargs["header"] = op.header


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

Support passing `skiprows` when reading from csv files.

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #193 

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass
