### PR TITLE
BUG: Fix wrong length of DataFrame

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -114,7 +114,7 @@ jobs:
       env:
         MODULE: ${{ matrix.module }}
       run: |
-        pip install numpy scipy cython coverage
+        pip install numpy scipy cython coverage flaky
         
         if [[ "$PYTHON" == "3.9" ]]; then
           conda install numba

--- a/python/xorbits/core/data.py
+++ b/python/xorbits/core/data.py
@@ -212,6 +212,23 @@ class DataRef(metaclass=DataRefMeta):
 
                 yield from gen()
 
+    def __len__(self):
+        from .._mars.core import HasShapeTileable
+        from .execution import run
+
+        if isinstance(self.data._mars_entity, HasShapeTileable):
+            try:
+                return int(self.data._mars_entity.shape[0])
+            except (IndexError, ValueError):
+                # shape is unknown, execute it
+                run(self)
+                try:
+                    return int(self.data._mars_entity.shape[0])
+                except (IndexError, ValueError):  # happens when dimension is 0
+                    return 0
+        else:
+            raise TypeError(f"object of type '{self.data.data_type}' has no len()")
+
     @safe_repr_str
     def __str__(self):
         from .execution import run

--- a/python/xorbits/core/data.py
+++ b/python/xorbits/core/data.py
@@ -225,7 +225,9 @@ class DataRef(metaclass=DataRefMeta):
                 try:
                     return int(self.data._mars_entity.shape[0])
                 except (IndexError, ValueError):  # happens when dimension is 0
-                    return 0
+                    raise TypeError(
+                        f"object with shape {self.data._mars_entity.shape} has no len()"
+                    )
         else:
             raise TypeError(f"object of type '{self.data.data_type}' has no len()")
 

--- a/python/xorbits/core/tests/test_execution.py
+++ b/python/xorbits/core/tests/test_execution.py
@@ -140,6 +140,9 @@ def test_len(setup, dummy_df, dummy_int_series, dummy_int_2d_array):
     assert len(filtered) == 2
     assert not need_to_execute(filtered)
 
+    with pytest.raises(TypeError):
+        len(dummy_int_2d_array.sum())
+
     obj = spawn(lambda _: 1)
     with pytest.raises(TypeError):
         len(obj)

--- a/python/xorbits/core/tests/test_execution.py
+++ b/python/xorbits/core/tests/test_execution.py
@@ -15,6 +15,7 @@
 import pytest
 
 from ...pandas import get_dummies
+from ...remote import spawn
 from ..execution import need_to_execute, run
 
 
@@ -138,6 +139,11 @@ def test_len(setup, dummy_df, dummy_int_series, dummy_int_2d_array):
     filtered = dummy_int_2d_array[dummy_int_2d_array < 2]
     assert len(filtered) == 2
     assert not need_to_execute(filtered)
+
+    obj = spawn(lambda _: 1)
+    with pytest.raises(TypeError):
+        len(obj)
+    assert need_to_execute(obj)
 
 
 @pytest.fixture()

--- a/python/xorbits/core/tests/test_execution.py
+++ b/python/xorbits/core/tests/test_execution.py
@@ -118,6 +118,28 @@ def test_manual_execution(setup, dummy_int_series):
     assert not any([need_to_execute(ref) for ref in series_to_execute])
 
 
+def test_len(setup, dummy_df, dummy_int_series, dummy_int_2d_array):
+    assert need_to_execute(dummy_df)
+    assert need_to_execute(dummy_int_series)
+    assert need_to_execute(dummy_int_2d_array)
+
+    assert len(dummy_df) == 3
+    assert len(dummy_int_series) == 5
+    assert len(dummy_int_2d_array) == 3
+
+    filtered = dummy_df[dummy_df["foo"] < 2]
+    assert len(filtered) == 2
+    assert not need_to_execute(filtered)
+
+    filtered = dummy_int_series[dummy_int_series < 2]
+    assert len(filtered) == 1
+    assert not need_to_execute(filtered)
+
+    filtered = dummy_int_2d_array[dummy_int_2d_array < 2]
+    assert len(filtered) == 2
+    assert not need_to_execute(filtered)
+
+
 @pytest.fixture()
 def ip():
     from IPython.testing.globalipapp import start_ipython

--- a/python/xorbits/numpy/mars_adapters/core.py
+++ b/python/xorbits/numpy/mars_adapters/core.py
@@ -80,6 +80,7 @@ def _collect_tensor_magic_methods() -> Set[str]:
         "__str__",
         "__setattr__",
         "__getattr__",
+        "__len__",
     }
 
     for mars_cls in MARS_TENSOR_TYPE:

--- a/python/xorbits/pandas/mars_adapters/core.py
+++ b/python/xorbits/pandas/mars_adapters/core.py
@@ -95,6 +95,7 @@ def _collect_dataframe_magic_methods() -> Set[str]:
         "__str__",
         "__setattr__",
         "__getattr__",
+        "__len__",
     }
     all_cls = (
         MARS_DATAFRAME_TYPE

--- a/python/xorbits/pandas/mars_adapters/tests/test_mars_adapters.py
+++ b/python/xorbits/pandas/mars_adapters/tests/test_mars_adapters.py
@@ -77,7 +77,6 @@ def test_dataframe_indexing(setup, dummy_df):
     xdf = dummy_df.at[0, "foo"]
     assert isinstance(xdf, DataRef)
 
-    assert 0 == len(xdf)
     assert 0 == xdf.to_numpy()
 
     assert isinstance(dummy_df.iat, DataFrameIat)
@@ -85,7 +84,6 @@ def test_dataframe_indexing(setup, dummy_df):
     xdf = dummy_df.iat[0, 0]
     assert isinstance(xdf, DataRef)
 
-    assert 0 == len(xdf)
     assert 0 == xdf.to_numpy()
 
 
@@ -94,28 +92,24 @@ def test_series_indexing(setup, dummy_int_series):
     res = dummy_int_series.loc[0]
     assert isinstance(res, DataRef)
 
-    assert 0 == len(res)
     assert 1 == res.to_numpy()
 
     assert isinstance(dummy_int_series.iloc, DataFrameIloc)
     res = dummy_int_series.iloc[0]
     assert isinstance(res, DataRef)
 
-    assert 0 == len(res)
     assert 1 == res.to_numpy()
 
     assert isinstance(dummy_int_series.at, DataFrameAt)
     res = dummy_int_series.at[1]
     assert isinstance(res, DataRef)
 
-    assert 0 == len(res)
     assert 2 == res.to_numpy()
 
     assert isinstance(dummy_int_series.iat, DataFrameIat)
     res = dummy_int_series.iat[1]
     assert isinstance(res, DataRef)
 
-    assert 0 == len(res)
     assert 2 == res.to_numpy()
 
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
For those data with unknown shape, we return 0 when call `len(df)`, which is confused for users. In this PR, trigger execution if its shape is unknown and return the correct length. 


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #216 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
