### PR TITLE
BLD: Drop Python 3.7 and support Python 3.11 for docker and CI

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -9,13 +9,13 @@ pull_request_rules:
     conditions:
       - "#approved-reviews-by>=2"
       - check-success=lint (ubuntu-latest, 3.10)
-      - check-success=build_test_job (ubuntu-latest, 3.7, xorbits)
       - check-success=build_test_job (ubuntu-latest, 3.8, xorbits)
       - check-success=build_test_job (ubuntu-latest, 3.9, xorbits)
       - check-success=build_test_job (ubuntu-latest, 3.10, xorbits)
-      - check-success=build_test_job (macos-latest, 3.7, xorbits)
+      - check-success=build_test_job (ubuntu-latest, 3.11, xorbits)
+      - check-success=build_test_job (macos-latest, 3.8, xorbits)
       - check-success=build_test_job (macos-latest, 3.11, xorbits)
-      - check-success=build_test_job (windows-latest, 3.7, xorbits)
+      - check-success=build_test_job (windows-latest, 3.8, xorbits)
       - check-success=build_test_job (windows-latest, 3.11, xorbits)
       - check-success=build_test_job (ubuntu-latest, _mars/dataframe, 3.9)
       - check-success=build_test_job (ubuntu-latest, _mars/tensor, 3.9)

--- a/.github/workflows/docker-cd.yaml
+++ b/.github/workflows/docker-cd.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ "3.7", "3.8", "3.9", "3.10" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11" ]
     steps:
       - name: Check out code
         uses: actions/checkout@v3
@@ -79,7 +79,7 @@ jobs:
           
       - name: Set default image
         shell: bash
-        if: matrix.python-version == '3.9'
+        if: matrix.python-version == '3.10'
         env:
           DOCKER_ORG: ${{ secrets.DOCKERHUB_USERNAME }}
           PY_VERSION: ${{ matrix.python-version }}

--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -76,14 +76,11 @@ jobs:
         module: ["xorbits", "kubernetes"]
         exclude:
           - { os: macos-latest, python-version: 3.10}
-          - { os: macos-latest, python-version: 3.8 }
           - { os: macos-latest, python-version: 3.9}
           - { os: windows-latest, python-version: 3.10}
-          - { os: windows-latest, python-version: 3.8}
           - { os: windows-latest, python-version: 3.9}
           - { os: windows-latest, module: kubernetes}
           - { os: macos-latest, module: kubernetes}
-          - { python-version: 3.11, module: kubernetes}
         include:
           - { os: ubuntu-latest, module: _mars/dataframe, python-version: 3.9 }
           - { os: ubuntu-latest, module: _mars/tensor, python-version: 3.9 }

--- a/python/xorbits/_mars/learn/contrib/utils.py
+++ b/python/xorbits/_mars/learn/contrib/utils.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 
 import numpy as np
 
@@ -66,10 +65,6 @@ def config_mod_getattr(mod_dict, globals_):
             return cls
         else:  # pragma: no cover
             raise AttributeError(name)
-
-    if sys.version_info[:2] < (3, 7):
-        for _mod in mod_dict.keys():
-            __getattr__(_mod)
 
     def __dir__():
         return sorted([n for n in globals_ if not n.startswith("_")] + list(mod_dict))

--- a/python/xorbits/_mars/lib/aio/_runners.py
+++ b/python/xorbits/_mars/lib/aio/_runners.py
@@ -30,12 +30,8 @@ Backport of the asyncio.runners module from Python 3.7.
 
 import asyncio
 import weakref
+from asyncio import get_running_loop
 from typing import Any, Awaitable, Coroutine, TypeVar, Union
-
-try:
-    from asyncio import get_running_loop  # noqa Python >=3.7
-except ImportError:  # pragma: no cover
-    from asyncio.events import _get_running_loop as get_running_loop  # pragma: no cover
 
 __all__ = ("run", "get_running_loop")
 _T = TypeVar("_T")

--- a/python/xorbits/_mars/oscar/tests/test_batch.py
+++ b/python/xorbits/_mars/oscar/tests/test_batch.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import asyncio
-import sys
 
 import pytest
 
@@ -84,9 +83,6 @@ def test_extensible_bind():
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("use_async", [False, True])
-@pytest.mark.skipif(
-    sys.version_info[:2] < (3, 7), reason="only run with Python 3.7 or greater"
-)
 async def test_extensible_no_batch(use_async):
     class TestClass:
         def __init__(self):
@@ -175,9 +171,6 @@ async def test_extensible_batch_only(use_async):
 
 
 @pytest.mark.asyncio
-@pytest.mark.skipif(
-    sys.version_info[:2] < (3, 7), reason="only run with Python 3.7 or greater"
-)
 @pytest.mark.parametrize("use_async", [False, True])
 async def test_extensible_single_with_batch(use_async):
     class TestClass:

--- a/python/xorbits/_mars/tests/test_utils.py
+++ b/python/xorbits/_mars/tests/test_utils.py
@@ -423,10 +423,6 @@ def test_quiet_stdio():
 
 
 @pytest.mark.asyncio
-@pytest.mark.skipif(
-    sys.version_info[:2] < (3, 7),
-    reason="asyncio task timeout detector is not supported on python versions below 3.7",
-)
 async def test_asyncio_task_timeout_detector():
     log_file_name = "test_asyncio_task_timeout_detector.log"
     try:

--- a/python/xorbits/_mars/utils.py
+++ b/python/xorbits/_mars/utils.py
@@ -1479,25 +1479,20 @@ def register_asyncio_task_timeout_detector(
                 "MARS_DEBUG_ASYNCIO_TASK_EXCLUDE_FILTERS", "mars/oscar"
             )
             task_exclude_filters = task_exclude_filters.split(";")
-        if sys.version_info[:2] < (3, 7):
-            logger.warning(
-                "asyncio tasks timeout detector is not supported under python %s",
-                sys.version,
+
+        loop = asyncio.get_running_loop()
+        logger.info(
+            "Create asyncio tasks timeout detector with check_interval %s task_timeout_seconds %s "
+            "task_exclude_filters %s",
+            check_interval,
+            task_timeout_seconds,
+            task_exclude_filters,
+        )
+        return loop.create_task(
+            asyncio_task_timeout_detector(
+                check_interval, task_timeout_seconds, task_exclude_filters
             )
-        else:
-            loop = asyncio.get_running_loop()
-            logger.info(
-                "Create asyncio tasks timeout detector with check_interval %s task_timeout_seconds %s "
-                "task_exclude_filters %s",
-                check_interval,
-                task_timeout_seconds,
-                task_exclude_filters,
-            )
-            return loop.create_task(
-                asyncio_task_timeout_detector(
-                    check_interval, task_timeout_seconds, task_exclude_filters
-                )
-            )
+        )
     else:
         return None
 

--- a/python/xorbits/compat/_constants.py
+++ b/python/xorbits/compat/_constants.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-SUPPORTED_PY_VERSIONS = ["3.7", "3.8", "3.9", "3.10"]
+SUPPORTED_PY_VERSIONS = ["3.8", "3.9", "3.10", "3.11"]
 
 # Packages that require the compatible version between local and cluster
 COMPATIBLE_DEPS = ["cloudpickle"]

--- a/python/xorbits/deploy/docker/Dockerfile
+++ b/python/xorbits/deploy/docker/Dockerfile
@@ -5,8 +5,12 @@ FROM ${BASE_CONTAINER}
 # Run this under `xorbits` dir
 COPY . /opt/xorbits/
 
+SHELL ["/bin/bash", "-c"]
+ARG PYTHON_VERSION=3.9
 RUN cd /opt/xorbits/python && \
-    python setup.py build_ext -i && \
+    if [ "$PYTHON_VERSION" == "3.11" ] ; \
+    then CFLAGS="-DCYTHON_FAST_THREAD_STATE=0" python setup.py build_ext -i ; \
+    else python setup.py build_ext -i ; fi && \
     npm cache clean --force && \
     python setup.py build_web && \
     rm -rf /opt/xorbits/python/xorbits/web/ui/node_modules

--- a/python/xorbits/deploy/docker/Dockerfile.base
+++ b/python/xorbits/deploy/docker/Dockerfile.base
@@ -2,14 +2,6 @@ ARG BASE_CONTAINER=continuumio/miniconda3:4.12.0
 ARG PYTHON_VERSION=3.9
 FROM ${BASE_CONTAINER} AS base
 
-FROM base AS py3.7-base
-SHELL ["/bin/bash", "-c"]
-ARG PYTHON_VERSION=3.9
-RUN if [ "$PYTHON_VERSION" == "3.7" ] ; then /opt/conda/bin/conda update -n base -c defaults conda \
-    && /opt/conda/bin/conda install python=3.7 numpy\<=1.21.6 pandas\<=1.3.5 \
-    && pip install -U pip \
-    && pip install pickle5 shared-memory38>=0.1.1 ; fi
-
 FROM base AS py3.8-base
 SHELL ["/bin/bash", "-c"]
 ARG PYTHON_VERSION=3.9
@@ -25,13 +17,18 @@ SHELL ["/bin/bash", "-c"]
 ARG PYTHON_VERSION=3.9
 RUN if [ "$PYTHON_VERSION" == "3.10" ] ; then /opt/conda/bin/conda install -c conda-forge python=3.10 numpy\>=1.14.0 pandas\>=1.5.0 ; fi
 
+FROM base AS py3.11-base
+SHELL ["/bin/bash", "-c"]
+ARG PYTHON_VERSION=3.9
+RUN if [ "$PYTHON_VERSION" == "3.11" ] ; then \
+    /opt/conda/bin/conda install --freeze-installed -c conda-forge \
+    python=3.11 numpy\>=1.14.0 pandas\>=1.5.0 cython\>=0.29.33 scipy\>=1.9.2 \
+    mkl numexpr psutil scikit-learn sqlalchemy tornado lz4 ; fi
+
 FROM py${PYTHON_VERSION}-base AS final
 RUN /opt/conda/bin/conda install \
-    cloudpickle \
     cython \
-    greenlet \
     mkl \
-    numba \
     numexpr \
     psutil \
     scikit-learn \
@@ -40,12 +37,11 @@ RUN /opt/conda/bin/conda install \
     tornado \
     lz4 \
   && /opt/conda/bin/conda install -c conda-forge \
-    libiconv \
     pyarrow\>=1.0 \
-    tiledb-py \
     python-kubernetes \
     uvloop \
   && pip install -U \
+    cloudpickle \
     adlfs \
     fsspec>=2022.7.1,!=2022.8.0 \
     s3fs \


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

- clean code for python 3.7 or below
- drop 3.7
- support 3.11

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #245 
Fixes #246 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
