### PR TITLE
BUG: fix error when inputting 1d array for ```np.tril``` 

### DIFF
--- a/python/xorbits/_mars/tensor/datasource/tests/test_datasource.py
+++ b/python/xorbits/_mars/tensor/datasource/tests/test_datasource.py
@@ -457,6 +457,48 @@ def test_triu_tril():
     assert isinstance(t.chunks[2].op, TensorTril)
     assert isinstance(t.chunks[3].op, TensorZeros)
 
+    # test broadcast
+    a_data = np.ones(5)
+    a = tensor(a, chunk_size=2)
+
+    t = tril(a)
+
+    assert t.op.gpu is None
+
+    t = tile(t)
+    assert len(t.chunks) == 4
+    assert isinstance(t.chunks[0].op, TensorTril)
+    assert isinstance(t.chunks[1].op, TensorZeros)
+    assert isinstance(t.chunks[2].op, TensorTril)
+    assert isinstance(t.chunks[3].op, TensorTril)
+
+    t = tril(a, k=1)
+
+    t = tile(t)
+    assert len(t.chunks) == 4
+    assert isinstance(t.chunks[0].op, TensorTril)
+    assert isinstance(t.chunks[1].op, TensorTril)
+    assert isinstance(t.chunks[2].op, TensorTril)
+    assert isinstance(t.chunks[3].op, TensorTril)
+
+    t = tril(a, k=-1)
+
+    t = tile(t)
+    assert len(t.chunks) == 4
+    assert isinstance(t.chunks[0].op, TensorTril)
+    assert isinstance(t.chunks[1].op, TensorZeros)
+    assert isinstance(t.chunks[2].op, TensorTril)
+    assert isinstance(t.chunks[3].op, TensorTril)
+
+    t = tril(a, k=-2)
+
+    t = tile(t)
+    assert len(t.chunks) == 4
+    assert isinstance(t.chunks[0].op, TensorZeros)
+    assert isinstance(t.chunks[1].op, TensorZeros)
+    assert isinstance(t.chunks[2].op, TensorTril)
+    assert isinstance(t.chunks[3].op, TensorZeros)
+
 
 def test_set_tensor_inputs():
     t1 = tensor([1, 2], chunk_size=2)

--- a/python/xorbits/_mars/tensor/datasource/tests/test_datasource_execution.py
+++ b/python/xorbits/_mars/tensor/datasource/tests/test_datasource_execution.py
@@ -892,6 +892,38 @@ def test_tril_execution(setup):
     assert isinstance(res, SparseNDArray)
     np.testing.assert_equal(res, expected)
 
+    a = np.ones(5)
+
+    t = tril(a)
+
+    res = t.execute().fetch()
+    expected = np.tril(np.ones(5))
+    np.testing.assert_equal(res, expected)
+
+    t = tril(a, k=1)
+
+    res = t.execute().fetch()
+    expected = np.tril(np.ones(5), k=1)
+    np.testing.assert_equal(res, expected)
+
+    t = tril(a, k=2)
+
+    res = t.execute().fetch()
+    expected = np.tril(np.ones(5), k=2)
+    np.testing.assert_equal(res, expected)
+
+    t = tril(a, k=-1)
+
+    res = t.execute().fetch()
+    expected = np.tril(np.ones(5), k=-1)
+    np.testing.assert_equal(res, expected)
+
+    t = tril(a, k=-2)
+
+    res = t.execute().fetch()
+    expected = np.tril(np.ones(5), k=-2)
+    np.testing.assert_equal(res, expected)
+
 
 def test_index_trick_execution(setup):
     mgrid = nd_grid()

--- a/python/xorbits/_mars/tensor/datasource/tri.py
+++ b/python/xorbits/_mars/tensor/datasource/tri.py
@@ -45,7 +45,7 @@ class TensorTri(TensorHasInput):
             yield
         tensor = op.outputs[0]
 
-        need_broadcast = False
+        is_1d_tensor = False
         m = op.input
         k = op.k
         is_triu = type(op) == TensorTriu
@@ -55,7 +55,7 @@ class TensorTri(TensorHasInput):
         cum_size = [np.cumsum(s).tolist() for s in nsplits]
 
         if len(cum_size) == 1:  # for 1d shape (x,), broadcast to (x, x)
-            need_broadcast = True
+            is_1d_tensor = True
             cum_size = [cum_size[0], cum_size[0]]
             nsplits = tuple([nsplits[0], nsplits[0]])
 
@@ -87,7 +87,7 @@ class TensorTri(TensorHasInput):
                 lu_pos = ru_pos[0], ld_pos[1]
                 chunk_k = fx(*lu_pos)
 
-                input_chunk = m.cix[out_idx if not need_broadcast else out_idx[0]]
+                input_chunk = m.cix[out_idx if not is_1d_tensor else out_idx[0]]
                 chunk_op = op.to_chunk_op(chunk_k)
                 out_chunk = chunk_op.new_chunk(
                     [input_chunk], shape=chunk_shape, index=out_idx, order=tensor.order
@@ -98,7 +98,7 @@ class TensorTri(TensorHasInput):
         new_op = op.copy()
         params = tensor.params
 
-        if need_broadcast:
+        if is_1d_tensor:
             params["shape"] = tuple([params["shape"][0], params["shape"][0]])
         params["chunks"] = out_chunks
         params["nsplits"] = nsplits

--- a/python/xorbits/_mars/tensor/datasource/tri.py
+++ b/python/xorbits/_mars/tensor/datasource/tri.py
@@ -45,6 +45,7 @@ class TensorTri(TensorHasInput):
             yield
         tensor = op.outputs[0]
 
+        need_broadcast = False
         m = op.input
         k = op.k
         is_triu = type(op) == TensorTriu
@@ -52,6 +53,11 @@ class TensorTri(TensorHasInput):
         fx = lambda x, y: x - y + k
         nsplits = m.nsplits
         cum_size = [np.cumsum(s).tolist() for s in nsplits]
+
+        if len(cum_size) == 1:  # for 1d shape (x,), broadcast to (x, x)
+            need_broadcast = True
+            cum_size = [cum_size[0], cum_size[0]]
+            nsplits = tuple([nsplits[0], nsplits[0]])
 
         out_chunks = []
         for out_idx in itertools.product(*[range(len(s)) for s in nsplits]):
@@ -81,7 +87,7 @@ class TensorTri(TensorHasInput):
                 lu_pos = ru_pos[0], ld_pos[1]
                 chunk_k = fx(*lu_pos)
 
-                input_chunk = m.cix[out_idx]
+                input_chunk = m.cix[out_idx if not need_broadcast else out_idx[0]]
                 chunk_op = op.to_chunk_op(chunk_k)
                 out_chunk = chunk_op.new_chunk(
                     [input_chunk], shape=chunk_shape, index=out_idx, order=tensor.order
@@ -91,8 +97,11 @@ class TensorTri(TensorHasInput):
 
         new_op = op.copy()
         params = tensor.params
+
+        if need_broadcast:
+            params["shape"] = tuple([params["shape"][0], params["shape"][0]])
         params["chunks"] = out_chunks
-        params["nsplits"] = m.nsplits
+        params["nsplits"] = nsplits
         return new_op.new_tensors(op.inputs, kws=[params])
 
     @classmethod


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

Broadcast 1d array of shape ```(x,)``` to ```(x, x)``` (same behavior as numpy). 

Example:
```python

import xorbits.numpy as np

np.tril(np.ones(5))
```

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #280 

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass
