### PR TITLE
BUG: Stop uploading node info after interpreter shutdown

### DIFF
--- a/python/xorbits/_mars/services/cluster/uploader.py
+++ b/python/xorbits/_mars/services/cluster/uploader.py
@@ -89,6 +89,13 @@ class NodeInfoUploaderActor(mo.Actor):
                     self._uploaded_future.set_result(None)
             except asyncio.CancelledError:  # pragma: no cover
                 break
+            except RuntimeError as ex:  # pragma: no cover
+                if "cannot schedule new futures after interpreter shutdown" not in str(
+                    ex
+                ):
+                    # when atexit is triggered, the default pool might be shutdown
+                    # and to_thread will fail
+                    break
             except (
                 Exception
             ) as ex:  # pragma: no cover  # noqa: E722  # nosec  # pylint: disable=bare-except
@@ -160,11 +167,6 @@ class NodeInfoUploaderActor(mo.Actor):
                     self._env_uploaded = True
                 except ValueError:
                     pass
-        except RuntimeError as ex:  # pragma: no cover
-            if "cannot schedule new futures after interpreter shutdown" not in str(ex):
-                # when atexit is triggered, the default pool might be shutdown
-                # and to_thread will fail
-                raise
         except:  # noqa: E722  # nosec  # pylint: disable=bare-except  # pragma: no cover
             logger.exception(f"Failed to upload node info")
             raise

--- a/python/xorbits/_mars/services/storage/core.py
+++ b/python/xorbits/_mars/services/storage/core.py
@@ -621,22 +621,33 @@ class StorageManagerActor(mo.StatelessActor):
 
         if self._cluster_api is not None:
             while True:
-                upload_tasks = []
-                for band, level_to_quota in self._quotas.items():
-                    for level, quota_ref in level_to_quota.items():
-                        total, used = await quota_ref.get_quota()
-                        used = int(used)
-                        if total is not None:
-                            total = int(total)
-                        storage_info = StorageInfo(
-                            storage_level=level, total_size=total, used_size=used
-                        )
-                        upload_tasks.append(
-                            self._cluster_api.set_band_storage_info.delay(
-                                band, storage_info
+                try:
+                    upload_tasks = []
+                    for band, level_to_quota in self._quotas.items():
+                        for level, quota_ref in level_to_quota.items():
+                            total, used = await quota_ref.get_quota()
+                            used = int(used)
+                            if total is not None:
+                                total = int(total)
+                            storage_info = StorageInfo(
+                                storage_level=level, total_size=total, used_size=used
                             )
-                        )
-                await self._cluster_api.set_band_storage_info.batch(*upload_tasks)
+                            upload_tasks.append(
+                                self._cluster_api.set_band_storage_info.delay(
+                                    band, storage_info
+                                )
+                            )
+                    await self._cluster_api.set_band_storage_info.batch(*upload_tasks)
+                except asyncio.CancelledError:  # pragma: no cover
+                    break
+                except RuntimeError as ex:  # pragma: no cover
+                    if (
+                        "cannot schedule new futures after interpreter shutdown"
+                        not in str(ex)
+                    ):
+                        # when atexit is triggered, the default pool might be shutdown
+                        # and to_thread will fail
+                        break
                 await asyncio.sleep(0.5)
 
     async def upload_disk_info(self):


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Stop uploading node info after interpreter shutdown.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
