### PR TITLE
ENH: Support Scale Up on K8S

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,5 @@ static/
 doc/source/savefig/
 
 asv/results
+
+.DS_Store

--- a/python/xorbits/_mars/services/cluster/api/oscar.py
+++ b/python/xorbits/_mars/services/cluster/api/oscar.py
@@ -272,11 +272,11 @@ class ClusterAPI(AbstractClusterAPI):
         return address
 
     async def request_workers(
-            self, worker_num: int, timeout: Optional[int] = None
+        self, worker_num: int, timeout: Optional[int] = None
     ) -> List[str]:
         node_allocator_ref = await self._get_node_allocator_ref()
         addresses = await node_allocator_ref.request_workers(worker_num, timeout)
-        return addresses    # pragma: no cover
+        return addresses  # pragma: no cover
 
     async def release_worker(self, address: str):
         node_allocator_ref = await self._get_node_allocator_ref()

--- a/python/xorbits/_mars/services/cluster/api/oscar.py
+++ b/python/xorbits/_mars/services/cluster/api/oscar.py
@@ -271,6 +271,13 @@ class ClusterAPI(AbstractClusterAPI):
         )
         return address
 
+    async def request_workers(
+            self, worker_num: int, timeout: Optional[int] = None
+    ) -> List[str]:
+        node_allocator_ref = await self._get_node_allocator_ref()
+        addresses = await node_allocator_ref.request_workers(worker_num, timeout)
+        return addresses    # pragma: no cover
+
     async def release_worker(self, address: str):
         node_allocator_ref = await self._get_node_allocator_ref()
         await node_allocator_ref.release_worker(address)

--- a/python/xorbits/_mars/services/cluster/api/oscar.py
+++ b/python/xorbits/_mars/services/cluster/api/oscar.py
@@ -276,7 +276,7 @@ class ClusterAPI(AbstractClusterAPI):
     ) -> List[str]:
         node_allocator_ref = await self._get_node_allocator_ref()
         addresses = await node_allocator_ref.request_workers(worker_num, timeout)
-        return addresses  # pragma: no cover
+        return addresses
 
     async def release_worker(self, address: str):
         node_allocator_ref = await self._get_node_allocator_ref()

--- a/python/xorbits/_mars/services/cluster/api/web.py
+++ b/python/xorbits/_mars/services/cluster/api/web.py
@@ -395,4 +395,4 @@ class WebClusterAPI(AbstractClusterAPI, MarsWebAPIClientMixin):
         if timeout is not None:
             path += f"&&timeout={timeout}"
         res = await self._request_url("PATCH", path, data=b"")
-        return json.loads(res.body)["workers"]
+        return json.loads(res.body)["workers"]  # pragma: no cover

--- a/python/xorbits/_mars/services/cluster/api/web.py
+++ b/python/xorbits/_mars/services/cluster/api/web.py
@@ -387,7 +387,7 @@ class WebClusterAPI(AbstractClusterAPI, MarsWebAPIClientMixin):
             return str(json.loads(res.body)["content"])
 
     async def request_workers(
-            self, worker_num: int, timeout: Optional[int] = None
+        self, worker_num: int, timeout: Optional[int] = None
     ) -> List[str]:
         path = f"{self._address}/api/cluster/workers?worker_num={worker_num}"
         if timeout is not None:

--- a/python/xorbits/_mars/services/cluster/api/web.py
+++ b/python/xorbits/_mars/services/cluster/api/web.py
@@ -83,12 +83,12 @@ class ClusterWebAPIHandler(MarsServiceWebAPIHandler):
                 version = int(version)
 
             async for version, node_infos in cluster_api.watch_nodes(
-                    role,
-                    env=env,
-                    resource=resource,
-                    detail=detail,
-                    statuses=statuses,
-                    version=version,
+                role,
+                env=env,
+                resource=resource,
+                detail=detail,
+                statuses=statuses,
+                version=version,
             ):
                 result["version"] = version
                 result["nodes"] = self._convert_node_dict(node_infos)
@@ -125,7 +125,7 @@ class ClusterWebAPIHandler(MarsServiceWebAPIHandler):
                 version = int(version)
 
             async for version, bands in cluster_api.watch_all_bands(
-                    role, statuses=statuses, version=version
+                role, statuses=statuses, version=version
             ):
                 self.write(serialize_serializable((version, bands)))
                 break
@@ -220,15 +220,15 @@ class WebClusterAPI(AbstractClusterAPI, MarsWebAPIClientMixin):
         return res
 
     async def _get_nodes_info(
-            self,
-            nodes: List[str] = None,
-            role: NodeRole = None,
-            env: bool = False,
-            resource: bool = False,
-            detail: bool = False,
-            watch: bool = False,
-            statuses: Set[NodeStatus] = None,
-            version: Optional[int] = None,
+        self,
+        nodes: List[str] = None,
+        role: NodeRole = None,
+        env: bool = False,
+        resource: bool = False,
+        detail: bool = False,
+        watch: bool = False,
+        statuses: Set[NodeStatus] = None,
+        version: Optional[int] = None,
     ):
         statuses_str = (
             ",".join(str(status.value) for status in statuses) if statuses else ""
@@ -275,14 +275,14 @@ class WebClusterAPI(AbstractClusterAPI, MarsWebAPIClientMixin):
         return version, list(res.keys())
 
     async def get_nodes_info(
-            self,
-            nodes: List[str] = None,
-            role: NodeRole = None,
-            env: bool = False,
-            resource: bool = False,
-            detail: bool = False,
-            statuses: Set[NodeStatus] = None,
-            exclude_statuses: Set[NodeStatus] = None,
+        self,
+        nodes: List[str] = None,
+        role: NodeRole = None,
+        env: bool = False,
+        resource: bool = False,
+        detail: bool = False,
+        statuses: Set[NodeStatus] = None,
+        exclude_statuses: Set[NodeStatus] = None,
     ):
         statuses = self._calc_statuses(statuses, exclude_statuses)
         return await self._get_nodes_info(
@@ -297,14 +297,14 @@ class WebClusterAPI(AbstractClusterAPI, MarsWebAPIClientMixin):
 
     @watch_method
     async def watch_nodes(
-            self,
-            role: NodeRole,
-            env: bool = False,
-            resource: bool = False,
-            detail: bool = False,
-            statuses: Set[NodeStatus] = None,
-            exclude_statuses: Set[NodeStatus] = None,
-            version: Optional[int] = None,
+        self,
+        role: NodeRole,
+        env: bool = False,
+        resource: bool = False,
+        detail: bool = False,
+        statuses: Set[NodeStatus] = None,
+        exclude_statuses: Set[NodeStatus] = None,
+        version: Optional[int] = None,
     ) -> List[Dict[str, Dict]]:
         statuses = self._calc_statuses(statuses, exclude_statuses)
         return await self._get_nodes_info(
@@ -339,11 +339,11 @@ class WebClusterAPI(AbstractClusterAPI, MarsWebAPIClientMixin):
 
     @watch_method
     async def watch_all_bands(
-            self,
-            role: NodeRole = None,
-            statuses: List[NodeStatus] = None,
-            exclude_statuses: Set[NodeStatus] = None,
-            version: Optional[int] = None,
+        self,
+        role: NodeRole = None,
+        statuses: List[NodeStatus] = None,
+        exclude_statuses: Set[NodeStatus] = None,
+        version: Optional[int] = None,
     ):
         statuses = self._calc_statuses(statuses, exclude_statuses)
         statuses_str = (
@@ -375,7 +375,7 @@ class WebClusterAPI(AbstractClusterAPI, MarsWebAPIClientMixin):
         return list(json.loads(res.body)["stacks"])
 
     async def fetch_node_log(
-            self, size: int = None, address: str = None, offset: int = 0
+        self, size: int = None, address: str = None, offset: int = 0
     ) -> str:
         path = f"{self._address}/api/cluster/logs?address={address}"
         if size is not None:

--- a/python/xorbits/_mars/services/cluster/api/web.py
+++ b/python/xorbits/_mars/services/cluster/api/web.py
@@ -318,10 +318,10 @@ class WebClusterAPI(AbstractClusterAPI, MarsWebAPIClientMixin):
         )
 
     async def get_all_bands(
-            self,
-            role: NodeRole = None,
-            statuses: Set[NodeStatus] = None,
-            exclude_statuses: Set[NodeStatus] = None,
+        self,
+        role: NodeRole = None,
+        statuses: Set[NodeStatus] = None,
+        exclude_statuses: Set[NodeStatus] = None,
     ) -> Dict[BandType, Resource]:
         statuses = self._calc_statuses(statuses, exclude_statuses)
         statuses_str = (

--- a/python/xorbits/_mars/services/cluster/backends/base.py
+++ b/python/xorbits/_mars/services/cluster/backends/base.py
@@ -82,6 +82,13 @@ class AbstractClusterBackend(ABC):
     async def request_workers(
         self, worker_num: int, timeout: Optional[int] = None
     ) -> List[str]:
+        """
+        Create new workers
+
+        Returns
+        -------
+        Addresses of the new created workers
+        """
         raise NotImplementedError
 
     @abstractmethod

--- a/python/xorbits/_mars/services/cluster/backends/base.py
+++ b/python/xorbits/_mars/services/cluster/backends/base.py
@@ -79,6 +79,11 @@ class AbstractClusterBackend(ABC):
         Address of the new created worker
         """
 
+    async def request_workers(
+            self, worker_num: int, timeout: Optional[int] = None
+    ) -> List[str]:
+        raise NotImplementedError
+
     @abstractmethod
     async def release_worker(self, address: str):
         """

--- a/python/xorbits/_mars/services/cluster/backends/base.py
+++ b/python/xorbits/_mars/services/cluster/backends/base.py
@@ -80,7 +80,7 @@ class AbstractClusterBackend(ABC):
         """
 
     async def request_workers(
-            self, worker_num: int, timeout: Optional[int] = None
+        self, worker_num: int, timeout: Optional[int] = None
     ) -> List[str]:
         raise NotImplementedError
 

--- a/python/xorbits/_mars/services/cluster/supervisor/node_allocator.py
+++ b/python/xorbits/_mars/services/cluster/supervisor/node_allocator.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
+from typing import List, Optional
 
 import xoscar as mo
 
@@ -39,6 +39,11 @@ class NodeAllocatorActor(mo.StatelessActor):
         return await self._backend.request_worker(
             worker_cpu, worker_mem, timeout=timeout
         )
+
+    async def request_workers(
+            self, worker_num: int, timeout: Optional[int] = None
+    ) -> List[str]:
+        return await self._backend.request_workers(worker_num, timeout)
 
     async def release_worker(self, address: str):
         await self._backend.release_worker(address)

--- a/python/xorbits/_mars/services/cluster/supervisor/node_allocator.py
+++ b/python/xorbits/_mars/services/cluster/supervisor/node_allocator.py
@@ -41,7 +41,7 @@ class NodeAllocatorActor(mo.StatelessActor):
         )
 
     async def request_workers(
-            self, worker_num: int, timeout: Optional[int] = None
+        self, worker_num: int, timeout: Optional[int] = None
     ) -> List[str]:
         return await self._backend.request_workers(worker_num, timeout)
 

--- a/python/xorbits/_mars/services/cluster/tests/test_api.py
+++ b/python/xorbits/_mars/services/cluster/tests/test_api.py
@@ -173,10 +173,9 @@ async def test_web_api(actor_pool):
         f.write("foo bar baz")
     log_content = await web_api.fetch_node_log(size=-1, address=pool_addr)
     assert len(log_content) == 11
-
-    await MockClusterAPI.cleanup(pool_addr)
     with pytest.raises(NotImplementedError):
         await web_api.request_workers(worker_num=1, timeout=1)
+    await MockClusterAPI.cleanup(pool_addr)
 
 
 @pytest.mark.asyncio

--- a/python/xorbits/_mars/services/cluster/tests/test_api.py
+++ b/python/xorbits/_mars/services/cluster/tests/test_api.py
@@ -62,8 +62,8 @@ async def test_api(actor_pool):
 
     await mo.create_actor(TestActor, uid=TestActor.default_uid(), address=pool_addr)
     assert (await api.get_supervisor_refs([TestActor.default_uid()]))[
-       0
-   ].address == pool_addr
+        0
+    ].address == pool_addr
 
     bands = await api.get_all_bands()
     assert (pool_addr, "numa-0") in bands

--- a/python/xorbits/_mars/services/cluster/tests/test_api.py
+++ b/python/xorbits/_mars/services/cluster/tests/test_api.py
@@ -91,12 +91,6 @@ async def test_api(actor_pool):
         await api.request_worker(timeout=1)
     with pytest.raises(NotImplementedError):
         await api.request_workers(worker_num=1, timeout=1)
-    # with pytest.raises(ValueError) as exc:
-    #     await api.request_workers(worker_num=1, timeout=-1)
-    # assert exc.type == ValueError
-    # assert "Please specify a `timeout` that is greater than zero" in str(
-    #     exc.value
-    # )
     with pytest.raises(NotImplementedError):
         await api.release_worker("127.0.0.1:1234")
 

--- a/python/xorbits/_mars/services/cluster/tests/test_api.py
+++ b/python/xorbits/_mars/services/cluster/tests/test_api.py
@@ -62,8 +62,8 @@ async def test_api(actor_pool):
 
     await mo.create_actor(TestActor, uid=TestActor.default_uid(), address=pool_addr)
     assert (await api.get_supervisor_refs([TestActor.default_uid()]))[
-        0
-    ].address == pool_addr
+               0
+           ].address == pool_addr
 
     bands = await api.get_all_bands()
     assert (pool_addr, "numa-0") in bands
@@ -89,6 +89,14 @@ async def test_api(actor_pool):
         )
     with pytest.raises(NotImplementedError):
         await api.request_worker(timeout=1)
+    with pytest.raises(NotImplementedError):
+        await api.request_workers(worker_num=1, timeout=1)
+    # with pytest.raises(ValueError) as exc:
+    #     await api.request_workers(worker_num=1, timeout=-1)
+    # assert exc.type == ValueError
+    # assert "Please specify a `timeout` that is greater than zero" in str(
+    #     exc.value
+    # )
     with pytest.raises(NotImplementedError):
         await api.release_worker("127.0.0.1:1234")
 
@@ -173,6 +181,8 @@ async def test_web_api(actor_pool):
     assert len(log_content) == 11
 
     await MockClusterAPI.cleanup(pool_addr)
+    with pytest.raises(NotImplementedError):
+        await web_api.request_workers(worker_num=1, timeout=1)
 
 
 @pytest.mark.asyncio

--- a/python/xorbits/_mars/services/cluster/tests/test_api.py
+++ b/python/xorbits/_mars/services/cluster/tests/test_api.py
@@ -62,8 +62,8 @@ async def test_api(actor_pool):
 
     await mo.create_actor(TestActor, uid=TestActor.default_uid(), address=pool_addr)
     assert (await api.get_supervisor_refs([TestActor.default_uid()]))[
-               0
-           ].address == pool_addr
+           0
+       ].address == pool_addr
 
     bands = await api.get_all_bands()
     assert (pool_addr, "numa-0") in bands

--- a/python/xorbits/_mars/services/cluster/tests/test_api.py
+++ b/python/xorbits/_mars/services/cluster/tests/test_api.py
@@ -62,8 +62,8 @@ async def test_api(actor_pool):
 
     await mo.create_actor(TestActor, uid=TestActor.default_uid(), address=pool_addr)
     assert (await api.get_supervisor_refs([TestActor.default_uid()]))[
-           0
-       ].address == pool_addr
+       0
+   ].address == pool_addr
 
     bands = await api.get_all_bands()
     assert (pool_addr, "numa-0") in bands

--- a/python/xorbits/deploy/kubernetes/config.py
+++ b/python/xorbits/deploy/kubernetes/config.py
@@ -93,10 +93,16 @@ class RoleConfig(KubeConfig):
             "metadata": {"name": self._name, "namespace": self._namespace},
             "rules": [
                 {
-                    "apiGroups": self._api_groups,
-                    "resources": self._resources,
-                    "verbs": self._verbs,
-                }
+                    "apiGroups": ["", "apps"],
+                    "resources": [
+                        "pods",
+                        "endpoints",
+                        "services",
+                        "deployments",
+                        "deployments/scale",
+                    ],
+                    "verbs": ["get", "watch", "list", "patch"],
+                },
             ],
         }
 
@@ -779,6 +785,7 @@ class XorbitsSupervisorsConfig(XorbitsReplicationConfig):
         super().__init__(*args, **kwargs)
         if self._web_port:
             self.add_port(self._web_port)
+            self.add_env("MARS_K8S_SUPERVISOR_WEB_PORT", self._web_port)
 
     def config_liveness_probe(self) -> "TcpSocketProbeConfig":
         return TcpSocketProbeConfig(

--- a/python/xorbits/deploy/kubernetes/config.py
+++ b/python/xorbits/deploy/kubernetes/config.py
@@ -93,14 +93,13 @@ class RoleConfig(KubeConfig):
             "metadata": {"name": self._name, "namespace": self._namespace},
             "rules": [
                 {
-                    "apiGroups": ["", "apps"],
-                    "resources": [
-                        "pods",
-                        "endpoints",
-                        "services",
-                        "deployments",
-                        "deployments/scale",
-                    ],
+                    "apiGroups": self._api_groups,
+                    "resources": self._resources,
+                    "verbs": self._verbs,
+                },
+                {
+                    "apiGroups": ["apps"],
+                    "resources": ["deployments", "deployments/scale"],
                     "verbs": ["get", "watch", "list", "patch"],
                 },
             ],
@@ -785,7 +784,6 @@ class XorbitsSupervisorsConfig(XorbitsReplicationConfig):
         super().__init__(*args, **kwargs)
         if self._web_port:
             self.add_port(self._web_port)
-            self.add_env("MARS_K8S_SUPERVISOR_WEB_PORT", self._web_port)
 
     def config_liveness_probe(self) -> "TcpSocketProbeConfig":
         return TcpSocketProbeConfig(

--- a/python/xorbits/deploy/kubernetes/core.py
+++ b/python/xorbits/deploy/kubernetes/core.py
@@ -207,7 +207,7 @@ class K8SClusterBackend(AbstractClusterBackend):
             pods = self._client.list_namespaced_pod(
                 namespace=self._k8s_namespace,
                 _preload_content=False,
-                label_selector="xorbits/service-type=xorbitsworker",
+                label_selector="xorbits/service-type="+XorbitsWorkersConfig.rc_name,
             )
             pods_list = json.loads(pods.data)["items"]
             port = os.environ["MARS_K8S_SERVICE_PORT"]

--- a/python/xorbits/deploy/kubernetes/core.py
+++ b/python/xorbits/deploy/kubernetes/core.py
@@ -234,7 +234,7 @@ class K8SClusterBackend(AbstractClusterBackend):
         )
         deployment_data = json.loads(deployment.data)
         old_replica = deployment_data["status"]["replicas"]
-        old_workers = self.list_workers()
+        old_workers = self._list_workers()
         new_replica = old_replica + worker_num
         body = {"spec": {"replicas": new_replica}}
         self._apps_client.patch_namespaced_deployment_scale(

--- a/python/xorbits/deploy/kubernetes/core.py
+++ b/python/xorbits/deploy/kubernetes/core.py
@@ -204,7 +204,7 @@ class K8SClusterBackend(AbstractClusterBackend):
     ) -> List[str]:
         if worker_num <= 0:
             raise ValueError("Please specify a `worker_num` that is greater than zero")
-        if timeout < 0:
+        if timeout and timeout < 0:
             raise ValueError("Please specify a `timeout` that is greater than zero")
         start_time = time.time()
         deployment = self._client_for_apps.read_namespaced_deployment(

--- a/python/xorbits/deploy/kubernetes/core.py
+++ b/python/xorbits/deploy/kubernetes/core.py
@@ -244,7 +244,7 @@ class K8SClusterBackend(AbstractClusterBackend):
             if timeout is not None and (timeout + start_time) < time.time():
                 raise TimeoutError("Request worker timeout")
             new_workers = self.list_workers()
-            if len(new_workers) == new_replica:
+            if new_replica == len(new_workers):
                 return list(set(new_workers) - set(old_workers))
             await asyncio.sleep(1)
 

--- a/python/xorbits/deploy/kubernetes/core.py
+++ b/python/xorbits/deploy/kubernetes/core.py
@@ -200,7 +200,7 @@ class K8SClusterBackend(AbstractClusterBackend):
         raise NotImplementedError
 
     async def request_workers(
-            self, worker_num: int, timeout: Optional[int] = None
+        self, worker_num: int, timeout: Optional[int] = None
     ) -> List[str]:
         if worker_num <= 0:
             raise ValueError("Please specify a `worker_num` that is greater than zero")

--- a/python/xorbits/deploy/kubernetes/core.py
+++ b/python/xorbits/deploy/kubernetes/core.py
@@ -13,8 +13,10 @@
 # limitations under the License.
 
 import asyncio
+import json
 import logging
 import os
+import time
 from typing import Any, AsyncGenerator, Dict, List, Optional, TypeVar
 
 from ..._mars.deploy.utils import next_in_thread, wait_all_supervisors_ready
@@ -60,6 +62,7 @@ class K8SClusterBackend(AbstractClusterBackend):
         self._service_name = os.environ.get("MARS_K8S_SERVICE_NAME")
         self._full_label_selector = None
         self._client = client.CoreV1Api(client.ApiClient(self._k8s_config))
+        self._client_for_apps = client.AppsV1Api(client.ApiClient(self._k8s_config))
 
     @classmethod
     async def create(
@@ -195,6 +198,42 @@ class K8SClusterBackend(AbstractClusterBackend):
         timeout: Optional[int] = None,
     ) -> str:
         raise NotImplementedError
+
+    async def request_workers(
+            self, worker_num: int, timeout: Optional[int] = None
+    ) -> List[str]:
+        if worker_num <= 0:
+            raise ValueError("Please specify a `worker_num` that is greater than zero")
+        if timeout < 0:
+            raise ValueError("Please specify a `timeout` that is greater than zero")
+        start_time = time.time()
+        deployment = self._client_for_apps.read_namespaced_deployment(
+            name="xorbitsworker", namespace=self._k8s_namespace, _preload_content=False
+        )
+        deployment_data = json.loads(deployment.data)
+        old_replica = deployment_data["status"]["replicas"]
+        new_replica = old_replica + worker_num
+        body = {"spec": {"replicas": new_replica}}
+        self._client_for_apps.patch_namespaced_deployment_scale(
+            name="xorbitsworker", namespace=self._k8s_namespace, body=body
+        )
+        while True:
+            if timeout is not None and (timeout + start_time) < time.time():
+                raise TimeoutError("Request worker timeout")
+            new_workers = []
+            pods = self._client.list_namespaced_pod(
+                namespace=self._k8s_namespace,
+                _preload_content=False,
+                label_selector="xorbits/service-type=xorbitsworker",
+            )
+            pods_list = json.loads(pods.data)["items"]
+            port = os.environ["MARS_K8S_SERVICE_PORT"]
+            for p in pods_list:
+                if "podIP" in p["status"]:
+                    new_workers.append(p["status"]["podIP"] + ":" + port)
+            if len(new_workers) == new_replica:
+                return new_workers
+            await asyncio.sleep(2)
 
     async def release_worker(self, address: str):
         raise NotImplementedError

--- a/python/xorbits/deploy/kubernetes/core.py
+++ b/python/xorbits/deploy/kubernetes/core.py
@@ -199,7 +199,7 @@ class K8SClusterBackend(AbstractClusterBackend):
     ) -> str:
         raise NotImplementedError
 
-    def list_workers(self):
+    def _list_workers(self):
         workers = []
         pods = self._client.list_namespaced_pod(
             namespace=self._k8s_namespace,
@@ -243,7 +243,7 @@ class K8SClusterBackend(AbstractClusterBackend):
         while True:
             if timeout is not None and (timeout + start_time) < time.time():
                 raise TimeoutError("Request worker timeout")
-            new_workers = self.list_workers()
+            new_workers = self._list_workers()
             if len(new_workers) == new_replica:
                 return list(set(new_workers) - set(old_workers))
             await asyncio.sleep(1)

--- a/python/xorbits/deploy/kubernetes/core.py
+++ b/python/xorbits/deploy/kubernetes/core.py
@@ -244,7 +244,7 @@ class K8SClusterBackend(AbstractClusterBackend):
             if timeout is not None and (timeout + start_time) < time.time():
                 raise TimeoutError("Request worker timeout")
             new_workers = self.list_workers()
-            if new_replica == len(new_workers):
+            if len(new_workers) == new_replica:
                 return list(set(new_workers) - set(old_workers))
             await asyncio.sleep(1)
 

--- a/python/xorbits/deploy/kubernetes/core.py
+++ b/python/xorbits/deploy/kubernetes/core.py
@@ -207,7 +207,7 @@ class K8SClusterBackend(AbstractClusterBackend):
             pods = self._client.list_namespaced_pod(
                 namespace=self._k8s_namespace,
                 _preload_content=False,
-                label_selector="xorbits/service-type="+XorbitsWorkersConfig.rc_name,
+                label_selector="xorbits/service-type=" + XorbitsWorkersConfig.rc_name,
             )
             pods_list = json.loads(pods.data)["items"]
             port = os.environ["MARS_K8S_SERVICE_PORT"]

--- a/python/xorbits/deploy/kubernetes/tests/test_kubernetes.py
+++ b/python/xorbits/deploy/kubernetes/tests/test_kubernetes.py
@@ -276,8 +276,7 @@ async def test_request_workers_insufficient():
         use_local_image=True,
     ) as cluster_client:
         cluster_api = WebClusterAPI(address=cluster_client.endpoint)
-        with pytest.raises(MemoryError) as exc:
+        with pytest.raises(SystemError) as exc:
             await cluster_api.request_workers(worker_num=1, timeout=30)
-        assert exc.type == MemoryError
+        assert exc.type == SystemError
         assert "Insufficient cpu" in str(exc.value)
-        simple_job()

--- a/python/xorbits/deploy/kubernetes/tests/test_kubernetes.py
+++ b/python/xorbits/deploy/kubernetes/tests/test_kubernetes.py
@@ -270,7 +270,5 @@ async def test_request_workers_insufficient():
         use_local_image=True,
     ) as cluster_client:
         cluster_api = WebClusterAPI(address=cluster_client.endpoint)
-        with pytest.raises(SystemError) as exc:
+        with pytest.raises(SystemError, match=r".* Insufficient cpu.*"):
             await cluster_api.request_workers(worker_num=1, timeout=30)
-        assert exc.type == SystemError
-        assert "Insufficient cpu" in str(exc.value)

--- a/python/xorbits/deploy/kubernetes/tests/test_kubernetes.py
+++ b/python/xorbits/deploy/kubernetes/tests/test_kubernetes.py
@@ -81,7 +81,7 @@ def _collect_coverage():
 def _build_docker_images(py_version: str):
     image_name = "xorbits-test-image:" + uuid.uuid1().hex
     xorbits_root = XORBITS_ROOT + "/"
-    docker_file_path = os.path.join(DOCKER_ROOT, "Dockerfile")[len(xorbits_root):]
+    docker_file_path = os.path.join(DOCKER_ROOT, "Dockerfile")[len(xorbits_root) :]
     try:
         build_proc = subprocess.Popen(
             [
@@ -229,13 +229,13 @@ def test_run_in_kubernetes():
 @pytest.mark.asyncio
 async def test_request_workers():
     with _start_kube_cluster(
-            supervisor_cpu=0.2,
-            supervisor_mem="1G",
-            worker_cpu=0.2,
-            worker_mem="1G",
-            worker_cache_mem="64m",
-            use_local_image=True,
-            pip=["Faker"],
+        supervisor_cpu=0.2,
+        supervisor_mem="1G",
+        worker_cpu=0.2,
+        worker_mem="1G",
+        worker_cache_mem="64m",
+        use_local_image=True,
+        pip=["Faker"],
     ) as cluster_client:
         cluster_api = WebClusterAPI(address=cluster_client.endpoint)
         with pytest.raises(ValueError) as exc:

--- a/python/xorbits/deploy/kubernetes/tests/test_kubernetes.py
+++ b/python/xorbits/deploy/kubernetes/tests/test_kubernetes.py
@@ -42,9 +42,9 @@ TEST_ROOT = os.path.dirname(os.path.abspath(__file__))
 DOCKER_ROOT = os.path.join((os.path.dirname(os.path.dirname(TEST_ROOT))), "docker")
 
 kube_available = (
-        find_executable("kubectl") is not None
-        and find_executable("docker") is not None
-        and k8s is not None
+    find_executable("kubectl") is not None
+    and find_executable("docker") is not None
+    and k8s is not None
 )
 
 

--- a/python/xorbits/deploy/kubernetes/tests/test_kubernetes.py
+++ b/python/xorbits/deploy/kubernetes/tests/test_kubernetes.py
@@ -178,15 +178,14 @@ def _start_kube_cluster(**kwargs):
 
         [p.terminate() for p in log_processes]
     finally:
-        # shutil.rmtree(temp_spill_dir)
-        # if cluster_client:
-        #     try:
-        #         cluster_client.stop(wait=True, timeout=20)
-        #     except TimeoutError:
-        #         pass
-        # _collect_coverage()
-        # _remove_docker_image(image_name, False)
-        print("HI")
+        shutil.rmtree(temp_spill_dir)
+        if cluster_client:
+            try:
+                cluster_client.stop(wait=True, timeout=20)
+            except TimeoutError:
+                pass
+        _collect_coverage()
+        _remove_docker_image(image_name, False)
 
 
 def simple_job():

--- a/python/xorbits/deploy/kubernetes/tests/test_kubernetes.py
+++ b/python/xorbits/deploy/kubernetes/tests/test_kubernetes.py
@@ -239,28 +239,22 @@ async def test_request_workers():
         use_local_image=True,
     ) as cluster_client:
         cluster_api = WebClusterAPI(address=cluster_client.endpoint)
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(
+            ValueError, match="Please specify a `timeout` that is greater than zero"
+        ):
             await cluster_api.request_workers(worker_num=1, timeout=-10)
-        assert exc.type == ValueError
-        assert "Please specify a `timeout` that is greater than zero" in str(exc.value)
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(
+            ValueError, match="Please specify a `worker_num` that is greater than zero"
+        ):
             await cluster_api.request_workers(worker_num=-10, timeout=1)
-        assert exc.type == ValueError
-        assert "Please specify a `worker_num` that is greater than zero" in str(
-            exc.value
-        )
-        with pytest.raises(ValueError) as exc:
+        with pytest.raises(
+            ValueError, match="Please specify a `worker_num` that is greater than zero"
+        ):
             await cluster_api.request_workers(worker_num=0, timeout=1)
-        assert exc.type == ValueError
-        assert "Please specify a `worker_num` that is greater than zero" in str(
-            exc.value
-        )
         new_workers = await cluster_api.request_workers(worker_num=1, timeout=300)
         assert len(new_workers) == 1
-        with pytest.raises(TimeoutError) as exc:
+        with pytest.raises(TimeoutError, match="Request worker timeout"):
             await cluster_api.request_workers(worker_num=1, timeout=0)
-        assert exc.type == TimeoutError
-        assert "Request worker timeout" in str(exc.value)
         simple_job()
 
 

--- a/python/xorbits/deploy/kubernetes/tests/test_kubernetes.py
+++ b/python/xorbits/deploy/kubernetes/tests/test_kubernetes.py
@@ -123,7 +123,7 @@ def _load_docker_env():
         export_pos = line.find("export")
         if export_pos < 0:
             continue
-        line = line[export_pos + 6:].strip()
+        line = line[export_pos + 6 :].strip()
         var, value = line.split("=", 1)
         os.environ[var] = value.strip('"')
 
@@ -192,13 +192,13 @@ def _start_kube_cluster(**kwargs):
 @pytest.mark.skipif(not kube_available, reason="Cannot run without kubernetes")
 def test_run_in_kubernetes():
     with _start_kube_cluster(
-            supervisor_cpu=0.5,
-            supervisor_mem="1G",
-            worker_cpu=0.5,
-            worker_mem="1G",
-            worker_cache_mem="64m",
-            use_local_image=True,
-            pip=["Faker"],
+        supervisor_cpu=0.5,
+        supervisor_mem="1G",
+        worker_cpu=0.5,
+        worker_mem="1G",
+        worker_cache_mem="64m",
+        use_local_image=True,
+        pip=["Faker"],
     ):
         a = xnp.ones((100, 100), chunk_size=30) * 2 * 1 + 1
         b = xnp.ones((100, 100), chunk_size=20) * 2 * 1 + 1

--- a/python/xorbits/deploy/kubernetes/tests/test_kubernetes.py
+++ b/python/xorbits/deploy/kubernetes/tests/test_kubernetes.py
@@ -270,5 +270,5 @@ async def test_request_workers_insufficient():
         use_local_image=True,
     ) as cluster_client:
         cluster_api = WebClusterAPI(address=cluster_client.endpoint)
-        with pytest.raises(SystemError, match=r".* Insufficient cpu.*"):
+        with pytest.raises(SystemError, match=r".*Insufficient cpu.*"):
             await cluster_api.request_workers(worker_num=1, timeout=30)


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #285 
Usage Example :
```python
from xorbits._mars.services.cluster import WebClusterAPI

cluster_api = WebClusterAPI(address='<your k8s cluster endpoint>')
await cluster_api.request_workers(worker_num=1)
```
## Check code requirements

- [X] tests added / passed (if needed)
- [X] Ensure all linting tests pass
