### PR TITLE
BUG: fetch vram data from local cluster

### DIFF
--- a/python/xorbits/_mars/dataframe/base/tests/test_base_execution.py
+++ b/python/xorbits/_mars/dataframe/base/tests/test_base_execution.py
@@ -59,7 +59,7 @@ def test_to_gpu_execution(setup_gpu):
     df = from_pandas_df(pdf, chunk_size=(13, 21))
     cdf = to_gpu(df)
 
-    res = cdf.execute().fetch()
+    res = cdf.execute().fetch(to_cpu=False)
     assert isinstance(res, cudf.DataFrame)
     pd.testing.assert_frame_equal(res.to_pandas(), pdf)
 
@@ -67,7 +67,7 @@ def test_to_gpu_execution(setup_gpu):
     series = from_pandas_series(pseries)
     cseries = series.to_gpu()
 
-    res = cseries.execute().fetch()
+    res = cseries.execute().fetch(to_cpu=False)
     assert isinstance(res, cudf.Series)
     pd.testing.assert_series_equal(res.to_pandas(), pseries)
 

--- a/python/xorbits/_mars/dataframe/datasource/tests/test_datasource_execution.py
+++ b/python/xorbits/_mars/dataframe/datasource/tests/test_datasource_execution.py
@@ -768,12 +768,16 @@ def test_read_csv_gpu_execution(setup_gpu):
         df.to_csv(file_path, index=False)
 
         pdf = pd.read_csv(file_path)
-        mdf = md.read_csv(file_path, gpu=True).execute().fetch()
+        mdf = md.read_csv(file_path, gpu=True).execute().fetch(to_cpu=False)
         pd.testing.assert_frame_equal(
             pdf.reset_index(drop=True), mdf.to_pandas().reset_index(drop=True)
         )
 
-        mdf2 = md.read_csv(file_path, gpu=True, chunk_bytes=200).execute().fetch()
+        mdf2 = (
+            md.read_csv(file_path, gpu=True, chunk_bytes=200)
+            .execute()
+            .fetch(to_cpu=False)
+        )
         pd.testing.assert_frame_equal(
             pdf.reset_index(drop=True), mdf2.to_pandas().reset_index(drop=True)
         )
@@ -1279,17 +1283,19 @@ def test_read_parquet_gpu_execution(setup_gpu):
         df.to_parquet(file_path, index=False)
 
         pdf = pd.read_parquet(file_path)
-        mdf = md.read_parquet(file_path, gpu=True).execute().fetch()
+        mdf = md.read_parquet(file_path, gpu=True).execute().fetch(to_cpu=False)
         pd.testing.assert_frame_equal(
             pdf.reset_index(drop=True), mdf.to_pandas().reset_index(drop=True)
         )
 
-        mdf2 = md.read_parquet(file_path, gpu=True).execute().fetch()
+        mdf2 = md.read_parquet(file_path, gpu=True).execute().fetch(to_cpu=False)
         pd.testing.assert_frame_equal(
             pdf.reset_index(drop=True), mdf2.to_pandas().reset_index(drop=True)
         )
 
-        mdf3 = md.read_parquet(file_path, gpu=True).head(3).execute().fetch()
+        mdf3 = (
+            md.read_parquet(file_path, gpu=True).head(3).execute().fetch(to_cpu=False)
+        )
         pd.testing.assert_frame_equal(
             pdf.reset_index(drop=True).head(3), mdf3.to_pandas().reset_index(drop=True)
         )
@@ -1308,7 +1314,7 @@ def test_read_parquet_gpu_execution(setup_gpu):
         df = md.read_parquet(
             file_path, groups_as_chunks=True, columns=["a", "b"], gpu=True
         )
-        result = df.execute().fetch().to_pandas()
+        result = df.execute().fetch(to_cpu=False).to_pandas()
         pd.testing.assert_frame_equal(
             result.reset_index(drop=True), test_df[["a", "b"]]
         )
@@ -1324,7 +1330,7 @@ def test_read_parquet_gpu_execution(setup_gpu):
         )
         df.to_parquet(tempdir, partition_cols=["c"])
         mdf = md.read_parquet(tempdir, gpu=True)
-        r = mdf.execute().fetch().to_pandas().astype(df.dtypes)
+        r = mdf.execute().fetch(to_cpu=False).to_pandas().astype(df.dtypes)
         pd.testing.assert_frame_equal(
             df.sort_values("a").reset_index(drop=True),
             r.sort_values("a").reset_index(drop=True),

--- a/python/xorbits/_mars/dataframe/groupby/tests/test_groupby_execution.py
+++ b/python/xorbits/_mars/dataframe/groupby/tests/test_groupby_execution.py
@@ -790,17 +790,18 @@ def test_gpu_groupby_agg(setup_gpu):
 
     r = mdf.groupby("a").sum()
     pd.testing.assert_frame_equal(
-        r.execute().fetch().to_pandas(), df1.groupby("a").sum()
+        r.execute().fetch(to_cpu=False).to_pandas(), df1.groupby("a").sum()
     )
 
     r = mdf.groupby("a").kurt()
     pd.testing.assert_frame_equal(
-        r.execute().fetch().to_pandas(), df1.groupby("a").kurt()
+        r.execute().fetch(to_cpu=False).to_pandas(), df1.groupby("a").kurt()
     )
 
     r = mdf.groupby("a").agg(["sum", "var"])
     pd.testing.assert_frame_equal(
-        r.execute().fetch().to_pandas(), df1.groupby("a").agg(["sum", "var"])
+        r.execute().fetch(to_cpu=False).to_pandas(),
+        df1.groupby("a").agg(["sum", "var"]),
     )
 
     rs = np.random.RandomState(0)
@@ -810,17 +811,18 @@ def test_gpu_groupby_agg(setup_gpu):
 
     r = ms.groupby(level=0).sum()
     pd.testing.assert_series_equal(
-        r.execute().fetch().to_pandas(), series1.groupby(level=0).sum()
+        r.execute().fetch(to_cpu=False).to_pandas(), series1.groupby(level=0).sum()
     )
 
     r = ms.groupby(level=0).kurt()
     pd.testing.assert_series_equal(
-        r.execute().fetch().to_pandas(), series1.groupby(level=0).kurt()
+        r.execute().fetch(to_cpu=False).to_pandas(), series1.groupby(level=0).kurt()
     )
 
     r = ms.groupby(level=0).agg(["sum", "var"])
     pd.testing.assert_frame_equal(
-        r.execute().fetch().to_pandas(), series1.groupby(level=0).agg(["sum", "var"])
+        r.execute().fetch(to_cpu=False).to_pandas(),
+        series1.groupby(level=0).agg(["sum", "var"]),
     )
 
 

--- a/python/xorbits/_mars/dataframe/reduction/tests/test_reduction_execution.py
+++ b/python/xorbits/_mars/dataframe/reduction/tests/test_reduction_execution.py
@@ -335,30 +335,30 @@ def test_gpu_execution(setup_gpu, check_ref_counts):
     df = to_gpu(md.DataFrame(df_raw, chunk_size=6))
 
     r = df.sum()
-    res = r.execute().fetch()
+    res = r.execute().fetch(to_cpu=False)
     pd.testing.assert_series_equal(res.to_pandas(), df_raw.sum())
 
     r = df.kurt()
-    res = r.execute().fetch()
+    res = r.execute().fetch(to_cpu=False)
     pd.testing.assert_series_equal(res.to_pandas(), df_raw.kurt())
 
     r = df.agg(["sum", "var"])
-    res = r.execute().fetch()
+    res = r.execute().fetch(to_cpu=False)
     pd.testing.assert_frame_equal(res.to_pandas(), df_raw.agg(["sum", "var"]))
 
     s_raw = pd.Series(np.random.rand(30))
     s = to_gpu(md.Series(s_raw, chunk_size=6))
 
     r = s.sum()
-    res = r.execute().fetch()
+    res = r.execute().fetch(to_cpu=False)
     assert pytest.approx(res) == s_raw.sum()
 
     r = s.kurt()
-    res = r.execute().fetch()
+    res = r.execute().fetch(to_cpu=False)
     assert pytest.approx(res) == s_raw.kurt()
 
     r = s.agg(["sum", "var"])
-    res = r.execute().fetch()
+    res = r.execute().fetch(to_cpu=False)
     pd.testing.assert_series_equal(res.to_pandas(), s_raw.agg(["sum", "var"]))
 
     s_raw = pd.Series(
@@ -367,7 +367,7 @@ def test_gpu_execution(setup_gpu, check_ref_counts):
     s = to_gpu(md.Series(s_raw, chunk_size=6))
 
     r = s.unique()
-    res = r.execute().fetch()
+    res = r.execute().fetch(to_cpu=False)
     np.testing.assert_array_equal(cp.asnumpy(res).sort(), s_raw.unique().sort())
 
 

--- a/python/xorbits/_mars/dataframe/sort/tests/test_sort_execution.py
+++ b/python/xorbits/_mars/dataframe/sort/tests/test_sort_execution.py
@@ -392,7 +392,7 @@ def test_gpu_execution(setup_gpu):
         raw = pd.DataFrame(rs.rand(100, 10), columns=["a" + str(i) for i in range(10)])
         mdf = DataFrame(raw, chunk_size=30).to_gpu()
 
-        result = mdf.sort_values(by="a0").execute().fetch()
+        result = mdf.sort_values(by="a0").execute().fetch(to_cpu=False)
         expected = raw.sort_values(by="a0")
         pd.testing.assert_frame_equal(result.to_pandas(), expected)
 
@@ -400,7 +400,7 @@ def test_gpu_execution(setup_gpu):
         raw = pd.Series(rs.rand(10))
         series = Series(raw).to_gpu()
 
-        result = series.sort_values().execute().fetch()
+        result = series.sort_values().execute().fetch(to_cpu=False)
         expected = raw.sort_values()
         pd.testing.assert_series_equal(result.to_pandas(), expected)
 
@@ -408,7 +408,7 @@ def test_gpu_execution(setup_gpu):
     raw = pd.DataFrame(np.random.rand(10, 10), columns=np.random.rand(10))
     mdf = DataFrame(raw).to_gpu()
 
-    result = mdf.sort_index().execute().fetch()
+    result = mdf.sort_index().execute().fetch(to_cpu=False)
     expected = raw.sort_index()
     pd.testing.assert_frame_equal(result.to_pandas(), expected)
 
@@ -419,6 +419,6 @@ def test_gpu_execution(setup_gpu):
     )
     series = Series(raw).to_gpu()
 
-    result = series.sort_index().execute().fetch()
+    result = series.sort_index().execute().fetch(to_cpu=False)
     expected = raw.sort_index()
     pd.testing.assert_series_equal(result.to_pandas(), expected)

--- a/python/xorbits/_mars/dataframe/tests/test_initializer.py
+++ b/python/xorbits/_mars/dataframe/tests/test_initializer.py
@@ -98,12 +98,12 @@ def test_dataframe_gpu_initializer(setup_gpu):
     # from raw cudf initializer
     raw = cudf.DataFrame(cupy.random.rand(100, 10), columns=list("ABCDEFGHIJ"))
     r = md.DataFrame(raw, chunk_size=13)
-    result = r.execute().fetch()
+    result = r.execute().fetch(to_cpu=False)
     pd.testing.assert_frame_equal(result.to_pandas(), raw.to_pandas())
 
     raw = cupy.random.rand(100, 10)
     r = md.DataFrame(raw, columns=list("ABCDEFGHIJ"), chunk_size=13)
-    result = r.execute().fetch()
+    result = r.execute().fetch(to_cpu=False)
     expected = cudf.DataFrame(raw, columns=list("ABCDEFGHIJ"))
     pd.testing.assert_frame_equal(result.to_pandas(), expected.to_pandas())
 
@@ -153,12 +153,12 @@ def test_series_gpu_initializer(setup_gpu):
     # from raw cudf initializer
     raw = cudf.Series(cupy.random.rand(100), name="a")
     r = md.Series(raw, chunk_size=13)
-    result = r.execute().fetch()
+    result = r.execute().fetch(to_cpu=False)
     pd.testing.assert_series_equal(result.to_pandas(), raw.to_pandas())
 
     raw = cupy.random.rand(100)
     r = md.Series(raw, name="a", chunk_size=13)
-    result = r.execute().fetch()
+    result = r.execute().fetch(to_cpu=False)
     expected = cudf.Series(raw, name="a")
     pd.testing.assert_series_equal(result.to_pandas(), expected.to_pandas())
 
@@ -200,11 +200,11 @@ def test_index_gpu_initializer(setup_gpu):
     # from raw cudf initializer
     raw = cudf.Index(cupy.random.rand(100), name="a")
     r = md.Index(raw, chunk_size=13)
-    result = r.execute().fetch()
+    result = r.execute().fetch(to_cpu=False)
     pd.testing.assert_index_equal(result.to_pandas(), raw.to_pandas())
 
     raw = cupy.random.rand(100)
     r = md.Index(raw, name="a", chunk_size=13)
-    result = r.execute().fetch()
+    result = r.execute().fetch(to_cpu=False)
     expected = cudf.Index(raw, name="a")
     pd.testing.assert_index_equal(result.to_pandas(), expected.to_pandas())

--- a/python/xorbits/_mars/dataframe/tseries/tests/test_tseries_execution.py
+++ b/python/xorbits/_mars/dataframe/tseries/tests/test_tseries_execution.py
@@ -91,7 +91,7 @@ def test_to_datetime_execution(setup):
 def test_to_datetime_gpu_execution(setup_gpu):
     s = md.Series(["3/11/2000", "3/12/2000", "3/13/2000"]).to_gpu()
     r = to_datetime(s, format="%m/%d/%Y")
-    result = r.execute().fetch().to_pandas()
+    result = r.execute().fetch(to_cpu=False).to_pandas()
     expected = pd.to_datetime(
         pd.Series(["3/11/2000", "3/12/2000", "3/13/2000"]), format="%m/%d/%Y"
     )

--- a/python/xorbits/_mars/deploy/oscar/session.py
+++ b/python/xorbits/_mars/deploy/oscar/session.py
@@ -1083,11 +1083,9 @@ class _IsolatedSession(AbstractAsyncSession):
         return storage_api
 
     async def fetch(self, *tileables, **kwargs) -> list:
-        if kwargs:  # pragma: no cover
-            unexpected_keys = ", ".join(list(kwargs.keys()))
-            raise TypeError(f"`fetch` got unexpected arguments: {unexpected_keys}")
-
-        fetcher = Fetcher.create(self._backend, get_storage_api=self._get_storage_api)
+        fetcher = Fetcher.create(
+            self._backend, get_storage_api=self._get_storage_api, **kwargs
+        )
 
         with enter_mode(build=True):
             chunks = []

--- a/python/xorbits/_mars/deploy/oscar/tests/session.py
+++ b/python/xorbits/_mars/deploy/oscar/tests/session.py
@@ -60,12 +60,8 @@ class CheckedSession(ObjectCheckMixin, _IsolatedSession):
 
     async def fetch(self, *tileables, **kwargs):
         extra_config = kwargs.pop("extra_config", dict())
-        if kwargs:
-            unexpected_keys = ", ".join(list(kwargs.keys()))
-            raise TypeError(f"`fetch` got unexpected arguments: {unexpected_keys}")
-
         self._check_options = self._extract_check_options(extra_config)
-        results = await super().fetch(*tileables)
+        results = await super().fetch(*tileables, **kwargs)
         return results
 
 

--- a/python/xorbits/_mars/services/task/execution/mars/fetcher.py
+++ b/python/xorbits/_mars/services/task/execution/mars/fetcher.py
@@ -31,6 +31,11 @@ class MarsFetcher(Fetcher):
         self._get_storage_api = get_storage_api
         self._storage_api_to_gets = defaultdict(list)
         self._counter = 0
+        self._to_cpu = kwargs.pop("to_cpu", True)
+
+        if kwargs:  # pragma: no cover
+            unexpected_keys = ", ".join(list(kwargs.keys()))
+            raise TypeError(f"unexpected arguments: {unexpected_keys}")
 
     async def append(self, chunk_key: str, chunk_meta: Dict, conditions: List = None):
         band = None
@@ -40,7 +45,9 @@ class MarsFetcher(Fetcher):
                 band = bands[0]
         storage_api = await self._get_storage_api(band)
         get = _GetWithIndex(
-            storage_api.get.delay(chunk_key, conditions=conditions, to_cpu=True),
+            storage_api.get.delay(
+                chunk_key, conditions=conditions, to_cpu=self._to_cpu
+            ),
             self._counter,
         )
         self._storage_api_to_gets[storage_api].append(get)

--- a/python/xorbits/_mars/services/task/execution/mars/fetcher.py
+++ b/python/xorbits/_mars/services/task/execution/mars/fetcher.py
@@ -40,7 +40,8 @@ class MarsFetcher(Fetcher):
                 band = bands[0]
         storage_api = await self._get_storage_api(band)
         get = _GetWithIndex(
-            storage_api.get.delay(chunk_key, conditions=conditions), self._counter
+            storage_api.get.delay(chunk_key, conditions=conditions, to_cpu=True),
+            self._counter,
         )
         self._storage_api_to_gets[storage_api].append(get)
         self._counter += 1

--- a/python/xorbits/_mars/tensor/arithmetic/tests/test_arithmetic_execution.py
+++ b/python/xorbits/_mars/tensor/arithmetic/tests/test_arithmetic_execution.py
@@ -789,8 +789,8 @@ def test_cupy_execution(setup_gpu):
 
     a = tensor(a_data, gpu=True, chunk_size=3)
     b = tensor(b_data, gpu=True, chunk_size=3)
-    res_binary = (a + b).execute().fetch()
+    res_binary = (a + b).execute().fetch(to_cpu=False)
     np.testing.assert_array_equal(res_binary.get(), (a_data + b_data))
 
-    res_unary = cos(a).execute().fetch()
+    res_unary = cos(a).execute().fetch(to_cpu=False)
     np.testing.assert_array_almost_equal(res_unary.get(), np.cos(a_data))

--- a/python/xorbits/_mars/tensor/base/tests/test_base_execution.py
+++ b/python/xorbits/_mars/tensor/base/tests/test_base_execution.py
@@ -1132,7 +1132,7 @@ def test_to_gpu_execution(setup_gpu):
 
     gx = to_gpu(x)
 
-    res = gx.execute().fetch()
+    res = gx.execute().fetch(to_cpu=False)
     np.testing.assert_array_equal(res.get(), raw)
 
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?
In a local deployment, the oscar APIs are generally used by the `Fetcher`. Thus we need to specify `to_cpu=True` when calling the storage API to convert vram object into main memory objects.

This PR make `to_cpu=True` the default behavior of `fetch` to avoid possible gpu related errors on the client side.

This PR also reserves the ability to skip the conversion, mostly for testing.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Resolves #351 

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass
