### PR TITLE
BUG: fetching from GPU

### DIFF
--- a/python/xorbits/_mars/dataframe/utils.py
+++ b/python/xorbits/_mars/dataframe/utils.py
@@ -1168,8 +1168,7 @@ def fetch_corner_data(df_or_series, session=None) -> pd.DataFrame:
         head = iloc(df_or_series)[:index_size]
         tail = iloc(df_or_series)[-index_size:]
         head_data, tail_data = ExecutableTuple([head, tail]).fetch(session=session)
-        xdf = cudf if head.op.is_gpu() else pd
-        return xdf.concat([head_data, tail_data], axis="index")
+        return pd.concat([head_data, tail_data], axis="index")
 
 
 class ReprSeries(pd.Series):

--- a/python/xorbits/_mars/storage/cuda.py
+++ b/python/xorbits/_mars/storage/cuda.py
@@ -252,6 +252,9 @@ class CudaStorage(StorageBackend):
 
     @implements(StorageBackend.get)
     async def get(self, object_id: str, **kwargs) -> object:
+        if kwargs:
+            raise NotImplementedError(f'Got unsupported args: {",".join(kwargs)}')
+
         from cudf.core.buffer import Buffer as CPBuffer
         from rmm import DeviceBuffer
 

--- a/python/xorbits/_mars/storage/tests/test_libs.py
+++ b/python/xorbits/_mars/storage/tests/test_libs.py
@@ -265,6 +265,9 @@ async def test_cuda_backend():
     get_data1 = await storage.get(put_info1.object_id)
     cupy.testing.assert_array_equal(data1, get_data1)
 
+    with pytest.raises(NotImplementedError):
+        await storage.get(put_info1.object_id, conditions=[])
+
     info1 = await storage.object_info(put_info1.object_id)
     assert info1.size == put_info1.size
 
@@ -280,6 +283,9 @@ async def test_cuda_backend():
     put_info2 = await storage.put(data2)
     get_data2 = await storage.get(put_info2.object_id)
     cudf.testing.assert_frame_equal(data2, get_data2)
+
+    with pytest.raises(NotImplementedError):
+        await storage.get(put_info2.object_id, conditions=[])
 
     info2 = await storage.object_info(put_info2.object_id)
     assert info2.size == put_info2.size


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?
1. Raise `NotImplementedError` when getting object from cuda storage backend with conditions and let the storage handler apply the conditions. See: https://github.com/xprobe-inc/xorbits/blob/1cc4e0ce8ef6699da5f3abee08e09718f091bfdf/python/xorbits/_mars/services/storage/handler.py#L112
2. always use pandas to concat fetched dataframes for repr.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Resolves #382 

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass
