### PR TITLE
TST: reuse existing tests for GPU testing

### DIFF
--- a/.github/workflows/python.yaml
+++ b/.github/workflows/python.yaml
@@ -256,7 +256,7 @@ jobs:
           pytest --cov-config=setup.cfg --cov-report=xml --durations=0 \
             --timeout=200 xorbits/_mars/deploy/oscar/tests/test_ray_dag_oscar.py -m ray
         elif [ "$MODULE" == "gpu" ]; then
-          pytest -m cuda --cov-config=setup.cfg --cov-report=xml --cov=xorbits        
+          pytest -m cuda --gpu --cov-config=setup.cfg --cov-report=xml --cov=xorbits xorbits  
         elif [ "$MODULE" == "pandas-1.0" ]; then
           pytest --timeout=1500 \
             -W ignore::PendingDeprecationWarning \

--- a/python/xorbits/_mars/tests/core.py
+++ b/python/xorbits/_mars/tests/core.py
@@ -174,6 +174,12 @@ def require_cudf(func):
     return func
 
 
+def support_cuda(func):
+    if pytest:
+        func = pytest.mark.cuda(func)
+    return func
+
+
 def require_ray(func):
     if pytest:
         func = pytest.mark.ray(func)

--- a/python/xorbits/conftest.py
+++ b/python/xorbits/conftest.py
@@ -30,7 +30,6 @@ def pytest_addoption(parser):
 
 @pytest.fixture
 def gpu(request):
-    print(f"GPU: {request.config.option.gpu}")
     return request.config.option.gpu
 
 

--- a/python/xorbits/conftest.py
+++ b/python/xorbits/conftest.py
@@ -22,6 +22,18 @@ from ._mars.deploy.oscar.session import clear_default_session
 from .tests.core import init_test
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--gpu", action="store_true", default=False, help="run test cases on GPU."
+    )
+
+
+@pytest.fixture
+def gpu(request):
+    print(f"GPU: {request.config.option.gpu}")
+    return request.config.option.gpu
+
+
 @pytest.fixture
 def doctest_namespace():
     return {"pd": pd, "np": np}


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

Setup a testing mechanism for letting current test cases run on GPU. For test cases that can run both on CPU and GPU,

1. always use the `setup_gpu` fixture since `setup_gpu` still works even there's no cuda device available.

2. mark test case with annotation `@support_cuda` so that it will be picked up when running pytest -m cuda, a.k.a. our GPU test suite.

3. in the test case, use the bool fixture `gpu` to init dataframes, series, and tensors. `gpu` is, by default, set to `False` so that test cases in CPU test suites still run on CPU. Our GPU test suite, however, runs with `pytest -m cuda --gpu`, where `gpu` is set to `True`, making the test cases run on GPU.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
#369 

## Check code requirements

- [x] tests added / passed (if needed)
- [x] Ensure all linting tests pass
