### PR TITLE
BUG: Fix `estimate_size` of `DataFrameReadParquet`

### DIFF
--- a/python/xorbits/_mars/dataframe/datasource/read_parquet.py
+++ b/python/xorbits/_mars/dataframe/datasource/read_parquet.py
@@ -586,7 +586,11 @@ class DataFrameReadParquet(
             .astype(np.int64)
             .item()
         )
-        all_columns = list(op.outputs[0].dtypes.index)
+        if op.columns is not None:
+            with open_file(op.path, storage_options=op.storage_options) as f:
+                all_columns = list(get_engine(op.engine).read_dtypes(f).index)
+        else:
+            all_columns = list(op.outputs[0].dtypes.index)
         columns = op.columns if op.columns else all_columns
         if op.use_arrow_dtype:
             scale = op.memory_scale or PARQUET_MEMORY_SCALE_WITH_ARROW_DTYPE

--- a/python/xorbits/_mars/dataframe/datasource/read_parquet.py
+++ b/python/xorbits/_mars/dataframe/datasource/read_parquet.py
@@ -600,7 +600,10 @@ class DataFrameReadParquet(
                 if col in columns and is_object_dtype(dt)
             ]
         )
-        pd_size = phy_size + n_strings * estimated_row_num * STRING_FIELD_OVERHEAD
+        if op.use_arrow_dtype:
+            pd_size = phy_size
+        else:
+            pd_size = phy_size + n_strings * estimated_row_num * STRING_FIELD_OVERHEAD
         ctx[op.outputs[0].key] = (pd_size, pd_size)
 
     def __call__(self, index_value=None, columns_value=None, dtypes=None):

--- a/python/xorbits/_mars/dataframe/datasource/tests/test_datasource.py
+++ b/python/xorbits/_mars/dataframe/datasource/tests/test_datasource.py
@@ -674,22 +674,14 @@ def test_read_parquet_estimate_size():
         chunk = tiled.chunks[0]
         estimate_size(sizes, chunk.op)
         estimated_size = sizes[chunk.key][0]
-        assert estimated_size > test_df.memory_usage(deep=True).sum()
+        assert estimated_size > test_df.memory_usage(deep=True).sum() * 1.5
 
-        df = read_parquet(file_path)
+        df = read_parquet(file_path, columns=["a", "c"])
         tiled = tile(df)
         sizes = dict()
         chunk = tiled.chunks[0]
         estimate_size(sizes, chunk.op)
-        estimated_size = sizes[chunk.key][0]
-        assert estimated_size > test_df.memory_usage(deep=True).sum()
-
-        df = read_parquet(file_path, columns=["a", "b"])
-        tiled = tile(df)
-        sizes = dict()
-        chunk = tiled.chunks[0]
-        estimate_size(sizes, chunk.op)
-        sizes[chunk.key][0] == estimated_size * 2 / 3
+        assert sizes[chunk.key][0] < estimated_size * (2 / 3)
 
         df = read_parquet(file_path, use_arrow_dtype=True)
         tiled = tile(df)
@@ -698,12 +690,12 @@ def test_read_parquet_estimate_size():
         estimate_size(sizes, chunk.op)
         estimated_size_arrow = sizes[chunk.key][0]
         estimated_size_arrow < estimated_size
-        assert estimated_size_arrow > test_df.memory_usage(deep=True).sum()
+        assert estimated_size_arrow > test_df.memory_usage(deep=True).sum() * 1.5
 
-        df = read_parquet(file_path, use_arrow_dtype=True, columns=["a", "b"])
+        df = read_parquet(file_path, use_arrow_dtype=True, columns=["a", "c"])
         tiled = tile(df)
         sizes = dict()
         chunk = tiled.chunks[0]
         estimate_size(sizes, chunk.op)
         estimated_size_arrow = sizes[chunk.key][0]
-        sizes[chunk.key][0] == estimated_size * 2 / 3
+        assert sizes[chunk.key][0] < estimated_size * 2 / 3

--- a/python/xorbits/_mars/dataframe/datasource/tests/test_datasource.py
+++ b/python/xorbits/_mars/dataframe/datasource/tests/test_datasource.py
@@ -26,6 +26,7 @@ import pytest
 from .... import tensor as mt
 from ....config import option_context
 from ....core import tile
+from ....core.operand import estimate_size
 from ...core import DatetimeIndex, IndexValue
 from ..core import merge_small_files
 from ..dataframe import from_pandas as from_pandas_df
@@ -39,6 +40,7 @@ from ..from_tensor import (
 from ..index import from_pandas as from_pandas_index
 from ..index import from_tileable
 from ..read_csv import DataFrameReadCSV, read_csv
+from ..read_parquet import read_parquet
 from ..read_sql import DataFrameReadSQL, read_sql_query, read_sql_table
 from ..series import from_pandas as from_pandas_series
 
@@ -651,3 +653,57 @@ def test_merge_small_files():
         df2.chunks[1].index_value.to_pandas(), pd.RangeIndex(8, 16)
     )
     assert df2.nsplits == ((8, 8), (4,))
+
+
+def test_read_parquet_estimate_size():
+    test_df = pd.DataFrame(
+        {
+            "a": np.arange(10).astype(np.int64, copy=False),
+            "b": [f"s{i}" for i in range(10)],
+            "c": np.random.rand(10),
+        }
+    )
+
+    with tempfile.TemporaryDirectory() as tempdir:
+        file_path = os.path.join(tempdir, "test.parquet")
+        test_df.to_parquet(file_path)
+
+        df = read_parquet(file_path)
+        tiled = tile(df)
+        sizes = dict()
+        chunk = tiled.chunks[0]
+        estimate_size(sizes, chunk.op)
+        estimated_size = sizes[chunk.key][0]
+        assert estimated_size > test_df.memory_usage(deep=True).sum()
+
+        df = read_parquet(file_path)
+        tiled = tile(df)
+        sizes = dict()
+        chunk = tiled.chunks[0]
+        estimate_size(sizes, chunk.op)
+        estimated_size = sizes[chunk.key][0]
+        assert estimated_size > test_df.memory_usage(deep=True).sum()
+
+        df = read_parquet(file_path, columns=["a", "b"])
+        tiled = tile(df)
+        sizes = dict()
+        chunk = tiled.chunks[0]
+        estimate_size(sizes, chunk.op)
+        sizes[chunk.key][0] == estimated_size * 2 / 3
+
+        df = read_parquet(file_path, use_arrow_dtype=True)
+        tiled = tile(df)
+        sizes = dict()
+        chunk = tiled.chunks[0]
+        estimate_size(sizes, chunk.op)
+        estimated_size_arrow = sizes[chunk.key][0]
+        estimated_size_arrow < estimated_size
+        assert estimated_size_arrow > test_df.memory_usage(deep=True).sum()
+
+        df = read_parquet(file_path, use_arrow_dtype=True, columns=["a", "b"])
+        tiled = tile(df)
+        sizes = dict()
+        chunk = tiled.chunks[0]
+        estimate_size(sizes, chunk.op)
+        estimated_size_arrow = sizes[chunk.key][0]
+        sizes[chunk.key][0] == estimated_size * 2 / 3


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

We call `op.estimate_size` to predict memory usage of execution, for `read_parquet`, the estimated size is incorrect in many cases. This PR fixes these and add ut to cover them.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #375 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
