### PR TITLE
BUG: series initializer on GPU

### DIFF
--- a/python/xorbits/_mars/dataframe/datasource/from_tensor.py
+++ b/python/xorbits/_mars/dataframe/datasource/from_tensor.py
@@ -668,6 +668,8 @@ class SeriesFromTensor(DataFrameOperand, DataFrameOperandMixin):
 
     @classmethod
     def execute(cls, ctx: Union[dict, Context], op: "SeriesFromTensor"):
+        xdf = cudf if op.is_gpu() else pd
+
         chunk = op.outputs[0]
         if op.input is not None:
             tensor_data = ctx[op.input.key]
@@ -686,7 +688,7 @@ class SeriesFromTensor(DataFrameOperand, DataFrameOperandMixin):
                 # index not specified
                 index_data = None
 
-        ctx[chunk.key] = pd.Series(
+        ctx[chunk.key] = xdf.Series(
             tensor_data, index=index_data, name=chunk.name, dtype=chunk.dtype
         )
 

--- a/python/xorbits/_mars/dataframe/datasource/series.py
+++ b/python/xorbits/_mars/dataframe/datasource/series.py
@@ -20,8 +20,11 @@ from ...config import options
 from ...core import OutputType
 from ...serialization.serializables import DataTypeField, SeriesField
 from ...tensor.utils import get_chunk_slices
+from ...utils import lazy_import
 from ..operands import DataFrameOperand, DataFrameOperandMixin
 from ..utils import decide_series_chunk_size, is_cudf, parse_index
+
+cudf = lazy_import("cudf")
 
 
 class SeriesDataSource(DataFrameOperand, DataFrameOperandMixin):
@@ -97,7 +100,7 @@ class SeriesDataSource(DataFrameOperand, DataFrameOperandMixin):
 
     @classmethod
     def execute(cls, ctx, op):
-        ctx[op.outputs[0].key] = op.data
+        ctx[op.outputs[0].key] = cudf.Series(op.data) if op.is_gpu() else op.data
 
 
 def from_pandas(data, chunk_size=None, gpu=None, sparse=False):

--- a/python/xorbits/_mars/dataframe/indexing/loc.py
+++ b/python/xorbits/_mars/dataframe/indexing/loc.py
@@ -30,7 +30,7 @@ from ...tensor.utils import calc_sliced_size, filter_inputs
 from ...utils import is_full_slice, lazy_import
 from ..core import DATAFRAME_TYPE, IndexValue
 from ..operands import DataFrameOperand, DataFrameOperandMixin
-from ..utils import is_index_value_identical, parse_index
+from ..utils import is_cudf, is_index_value_identical, parse_index
 from .iloc import DataFrameIlocSetItem
 from .index_lib import DataFrameLocIndexesHandler
 
@@ -528,7 +528,10 @@ class DataFrameLocGetItem(DataFrameOperand, DataFrameOperandMixin):
                     new_indexes.append(index)
 
             try:
-                r = df.loc[tuple(new_indexes)]
+                if is_cudf(df) and len(new_indexes) == 1:
+                    r = df.loc[new_indexes[0]]
+                else:
+                    r = df.loc[tuple(new_indexes)]
                 if str_loc_on_datetime_index:
                     # convert back to DataFrame or Series
                     if r.ndim == 0:

--- a/python/xorbits/_mars/dataframe/indexing/set_axis.py
+++ b/python/xorbits/_mars/dataframe/indexing/set_axis.py
@@ -178,10 +178,10 @@ class DataFrameSetAxis(DataFrameOperand, DataFrameOperandMixin):
         else:
             # cudf does not support set_axis.
             if op.axis == 0:
-                ctx[op.outputs[0].key] = in_data.set_index(value)
+                in_data.index = value
             else:
                 in_data.columns = value
-                ctx[op.outputs[0].key] = in_data
+            ctx[op.outputs[0].key] = in_data
 
 
 def _set_axis(df_or_axis, labels, axis=0, copy=False):

--- a/python/xorbits/_mars/services/storage/handler.py
+++ b/python/xorbits/_mars/services/storage/handler.py
@@ -111,8 +111,14 @@ class StorageHandlerActor(mo.Actor):
                 )
             except NotImplementedError:
                 data = yield self._clients[data_info.level].get(data_info.object_id)
+
                 try:
-                    sliced_value = data.iloc[tuple(conditions)]
+                    from ...dataframe.utils import is_cudf
+
+                    if is_cudf(data) and len(conditions) == 1:
+                        sliced_value = data.iloc[conditions[0]]
+                    else:
+                        sliced_value = data.iloc[tuple(conditions)]
                 except AttributeError:
                     sliced_value = data[tuple(conditions)]
                 res = sliced_value


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?
1. Allow GPU series init from xorbits, numpy or python list.
2. Fix the following error when fetching a GPU series:
```python
ArrowInvalid: could not convert slice(none, none, none) with type slice: did not recognize python value type when inferring an arrow data type
```

The root cause is that cuDF `iloc` cannot handle a tuple with a single element. Here's the way to reproduce the error:
```python
s = cudf.Series(list(range(100)))
s.iloc[(slice(0, 5),)]
```

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [x] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
