### PR TITLE
BUG: Fix agg('size') execute map result, which should be a series rather than a df

### DIFF
--- a/python/xorbits/_mars/dataframe/groupby/aggregation.py
+++ b/python/xorbits/_mars/dataframe/groupby/aggregation.py
@@ -1031,9 +1031,6 @@ class DataFrameGroupByAgg(DataFrameOperand, DataFrameOperandMixin):
                     if gpu and agg_func == "size"
                     else input_obj.agg(agg_func)
                 )
-                if result.ndim == 1:
-                    # when agg_func == size, agg only returns one single series.
-                    result = result.to_frame(agg_func)
             else:
                 result = input_obj.agg([agg_func])
                 result.columns = result.columns.droplevel(-1)


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

See details in issue #424 .

In this PR, just delete some codes. I have no idea why result should be turned to frame here.
In pandas, agg('size') can return a series.

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #424 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
