### PR TITLE
BUG: groupby same agg funcs leads to wrong results

### DIFF
--- a/python/xorbits/_mars/dataframe/groupby/tests/test_groupby_execution.py
+++ b/python/xorbits/_mars/dataframe/groupby/tests/test_groupby_execution.py
@@ -26,7 +26,7 @@ except ImportError:  # pragma: no cover
 from .... import dataframe as md
 from ....config import option_context
 from ....core.operand import OperandStage
-from ....tests.core import assert_groupby_equal, require_cudf, support_cuda
+from ....tests.core import assert_groupby_equal, require_cudf
 from ....utils import arrow_array_to_objects, pd_release_version
 from ...core import DATAFRAME_OR_SERIES_TYPE
 from ...utils import is_pandas_2
@@ -1595,7 +1595,8 @@ def test_gpu_groupby_size(data_type, chunked, as_index, sort, setup_gpu):
         pd.testing.assert_series_equal(expected, actual)
 
 
-@support_cuda
+# TODO: support cuda
+# @support_cuda
 def test_groupby_agg_on_same_funcs(setup_gpu, gpu):
     rs = np.random.RandomState(0)
     df = pd.DataFrame(

--- a/python/xorbits/_mars/dataframe/reduction/aggregation.py
+++ b/python/xorbits/_mars/dataframe/reduction/aggregation.py
@@ -999,7 +999,7 @@ def is_funcs_aggregate(func, func_kw=None, ndim=2):
             else:
                 to_check.append(v[1])
 
-    compiler = ReductionCompiler()
+    compiler = ReductionCompiler(store_source=True)
     for f in to_check:
         if f in _agg_functions:
             continue

--- a/python/xorbits/_mars/dataframe/reduction/core.py
+++ b/python/xorbits/_mars/dataframe/reduction/core.py
@@ -896,14 +896,14 @@ class ReductionCompiler:
         return fun
 
     @staticmethod
-    def _build_mock_return_object(func, func_name: Optional[str], input_dtype, ndim):
+    def _build_mock_return_object(func, func_idx: int, input_dtype, ndim):
         from ..initializer import DataFrame as MarsDataFrame
         from ..initializer import Series as MarsSeries
 
-        # if function names are not involved and the input functions are exactly the same, the
-        # output objects will have the same keys, which may cause incorrect results.
-        if func_name is None:  # pragma: no cover
-            func_name = ""
+        # for identical functions, the output objects will have the same keys, which may cause
+        # incorrect results.
+        # the index could be an ideal way to identify each of the functions.
+        func_name = f"f_{func_idx}"
 
         if ndim == 1:
             mock_series = build_empty_series(np.dtype(input_dtype), name=func_name)
@@ -930,7 +930,8 @@ class ReductionCompiler:
         from ..datasource.series import SeriesDataSource
         from ..indexing.where import DataFrameWhere
 
-        func_token = tokenize(func, self._axis, func_name, ndim)
+        func_idx = len(self._compiled_funcs)
+        func_token = tokenize(func, self._axis, func_name, func_idx, ndim)
         if func_token in _func_compile_cache:
             return _func_compile_cache[func_token]
         custom_reduction = func if isinstance(func, CustomReduction) else None
@@ -938,10 +939,10 @@ class ReductionCompiler:
         self._check_function_valid(func)
 
         try:
-            func_ret = self._build_mock_return_object(func, func_name, float, ndim=ndim)
+            func_ret = self._build_mock_return_object(func, func_idx, float, ndim=ndim)
         except (TypeError, AttributeError):  # pragma: no cover
             # we may encounter lambda x: x.str.cat(...), use an object series to test
-            func_ret = self._build_mock_return_object(func, func_name, object, ndim=1)
+            func_ret = self._build_mock_return_object(func, func_idx, object, ndim=1)
         output_limit = getattr(func, "output_limit", None) or 1
 
         if not isinstance(func_ret, ENTITY_TYPE):

--- a/python/xorbits/_mars/dataframe/reduction/core.py
+++ b/python/xorbits/_mars/dataframe/reduction/core.py
@@ -902,7 +902,7 @@ class ReductionCompiler:
 
         # if function names are not involved and the input functions are exactly the same, the
         # output objects will have the same keys, which may cause incorrect results.
-        if func_name is None:
+        if func_name is None:  # pragma: no cover
             func_name = ""
 
         if ndim == 1:
@@ -939,7 +939,7 @@ class ReductionCompiler:
 
         try:
             func_ret = self._build_mock_return_object(func, func_name, float, ndim=ndim)
-        except (TypeError, AttributeError):
+        except (TypeError, AttributeError):  # pragma: no cover
             # we may encounter lambda x: x.str.cat(...), use an object series to test
             func_ret = self._build_mock_return_object(func, func_name, object, ndim=1)
         output_limit = getattr(func, "output_limit", None) or 1

--- a/python/xorbits/_mars/dataframe/reduction/tests/test_reduction.py
+++ b/python/xorbits/_mars/dataframe/reduction/tests/test_reduction.py
@@ -489,22 +489,23 @@ def test_compile_function():
         )
         result = compiler.compile()
         # check pre_funcs
-        assert len(result.pre_funcs) == 2
+        assert len(result.pre_funcs) == 3
         assert (
-            "pow" in result.pre_funcs[0].func.__source__
-            or "pow" in result.pre_funcs[1].func.__source__
+            len([step for step in result.pre_funcs if "pow" in step.func.__source__])
+            == 2
         )
-        assert (
-            "pow" not in result.pre_funcs[0].func.__source__
-            or "pow" not in result.pre_funcs[1].func.__source__
-        )
+
         # check agg_funcs
-        assert len(result.agg_funcs) == 2
-        assert set(result.agg_funcs[i].map_func_name for i in range(2)) == {
+        assert len(result.agg_funcs) == 3
+        assert set(
+            result.agg_funcs[i].map_func_name for i in range(len(result.agg_funcs))
+        ) == {
             "count",
             "prod",
         }
-        assert set(result.agg_funcs[i].agg_func_name for i in range(2)) == {
+        assert set(
+            result.agg_funcs[i].agg_func_name for i in range(len(result.agg_funcs))
+        ) == {
             "sum",
             "prod",
         }
@@ -558,10 +559,19 @@ def test_compile_function():
     compiler.add_function(lambda x: -1 + x.sum(), ndim=2, cols=["b", "c"])
     result = compiler.compile()
     # check pre_funcs
-    assert len(result.pre_funcs) == 1
-    assert set(result.pre_funcs[0].columns) == set("abc")
+    assert len(result.pre_funcs) == 2
+    assert set([tuple(pre_func.columns) for pre_func in result.pre_funcs]) == {
+        (
+            "a",
+            "b",
+        ),
+        (
+            "b",
+            "c",
+        ),
+    }
     # check agg_funcs
-    assert len(result.agg_funcs) == 1
+    assert len(result.agg_funcs) == 2
     assert result.agg_funcs[0].map_func_name == "sum"
     assert result.agg_funcs[0].agg_func_name == "sum"
     # check post_funcs
@@ -578,15 +588,23 @@ def test_compile_function():
     compiler.add_function(lambda x: x.min(), ndim=2, cols=["c"])
     result = compiler.compile()
     # check pre_funcs
-    assert len(result.pre_funcs) == 1
-    assert set(result.pre_funcs[0].columns) == set("abc")
+    assert len(result.pre_funcs) == 3
+    assert set([tuple(pre_func.columns) for pre_func in result.pre_funcs]) == {
+        ("a",),
+        ("b",),
+        ("c",),
+    }
     # check agg_funcs
-    assert len(result.agg_funcs) == 2
+    assert len(result.agg_funcs) == 3
     assert result.agg_funcs[0].map_func_name == "sum"
     assert result.agg_funcs[0].agg_func_name == "sum"
     # check post_funcs
-    assert len(result.post_funcs) == 2
-    assert set(result.post_funcs[0].columns) == set("ab")
+    assert len(result.post_funcs) == 3
+    assert set([tuple(post_func.columns) for post_func in result.post_funcs]) == {
+        ("a",),
+        ("b",),
+        ("c",),
+    }
 
 
 def test_custom_aggregation():

--- a/python/xorbits/_mars/dataframe/reduction/tests/test_reduction_execution.py
+++ b/python/xorbits/_mars/dataframe/reduction/tests/test_reduction_execution.py
@@ -27,7 +27,7 @@ except ImportError:  # pragma: no cover
 from .... import dataframe as md
 from ....config import option_context
 from ....deploy.oscar.session import get_default_session
-from ....tests.core import require_cudf, require_cupy, support_cuda
+from ....tests.core import require_cudf, require_cupy
 from ....utils import lazy_import, pd_release_version
 from ... import CustomReduction, NamedAgg
 from ...base import to_gpu
@@ -1194,7 +1194,8 @@ def test_gpu_multi_agg_methods(setup_gpu):
     pd.testing.assert_series_equal(expected, res.to_pandas())
 
 
-@support_cuda
+# TODO: support cuda
+# @support_cuda
 def test_agg_on_same_funcs(setup_gpu, gpu):
     rs = np.random.RandomState(0)
     df = pd.DataFrame(

--- a/python/xorbits/_mars/dataframe/reduction/tests/test_reduction_execution.py
+++ b/python/xorbits/_mars/dataframe/reduction/tests/test_reduction_execution.py
@@ -27,7 +27,7 @@ except ImportError:  # pragma: no cover
 from .... import dataframe as md
 from ....config import option_context
 from ....deploy.oscar.session import get_default_session
-from ....tests.core import require_cudf, require_cupy
+from ....tests.core import require_cudf, require_cupy, support_cuda
 from ....utils import lazy_import, pd_release_version
 from ... import CustomReduction, NamedAgg
 from ...base import to_gpu
@@ -1192,3 +1192,31 @@ def test_gpu_multi_agg_methods(setup_gpu):
 
     res = mars_series.agg(["sum", "prod"]).execute().fetch(to_cpu=False)
     pd.testing.assert_series_equal(expected, res.to_pandas())
+
+
+@support_cuda
+def test_agg_on_same_funcs(setup_gpu, gpu):
+    rs = np.random.RandomState(0)
+    df = pd.DataFrame(
+        {
+            "a": rs.choice(["foo", "bar", "bar"], size=100),
+            "b": rs.choice(["foo", "bar", "bar"], size=100),
+            "c": rs.choice(["foo", "bar", "bar"], size=100),
+        },
+    )
+
+    mdf = md.DataFrame(df, chunk_size=34, gpu=gpu)
+
+    def g1(x):
+        return (x == "foo").sum()
+
+    def g2(x):
+        return (x != "bar").sum()
+
+    def g3(x):
+        # same as g2
+        return (x != "bar").sum()
+
+    pd.testing.assert_frame_equal(
+        df.aggregate((g1, g2, g3)), mdf.aggregate((g1, g2, g3)).execute().fetch()
+    )


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?
Take function names into consideration when compiling the aggregation functions so that identical functions with different names won't have same input and output keys.


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #432 

## Check code requirements

- [x] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
