### PR TITLE
BLD: Restrict numpy version in docker for python 3.8 and 3.9

### DIFF
--- a/python/xorbits/deploy/docker/Dockerfile.base
+++ b/python/xorbits/deploy/docker/Dockerfile.base
@@ -5,12 +5,12 @@ FROM ${BASE_CONTAINER} AS base
 FROM base AS py3.8-base
 SHELL ["/bin/bash", "-c"]
 ARG PYTHON_VERSION=3.9
-RUN if [ "$PYTHON_VERSION" == "3.8" ] ; then /opt/conda/bin/conda install -c conda-forge python=3.8 numpy\>=1.14.0 pandas\>=1.5.0 ; fi
+RUN if [ "$PYTHON_VERSION" == "3.8" ] ; then /opt/conda/bin/conda install -c conda-forge python=3.8 "numpy>=1.14.0,<1.23.0" pandas\>=1.5.0 ; fi
 
 FROM base AS py3.9-base
 SHELL ["/bin/bash", "-c"]
 ARG PYTHON_VERSION=3.9
-RUN if [ "$PYTHON_VERSION" == "3.9" ] ; then /opt/conda/bin/conda install -c conda-forge python=3.9 numpy\>=1.14.0 pandas\>=1.5.0 ; fi
+RUN if [ "$PYTHON_VERSION" == "3.9" ] ; then /opt/conda/bin/conda install -c conda-forge python=3.9 "numpy>=1.14.0,<1.23.0" pandas\>=1.5.0 ; fi
 
 FROM base AS py3.10-base
 SHELL ["/bin/bash", "-c"]


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

For python 3.8 and 3.9 in docker, numpy version should be <1.23.0.
Ref successful CD: https://github.com/xprobe-inc/xorbits/actions/runs/5006470463
failed CD: https://github.com/xprobe-inc/xorbits/actions/runs/4983660373

Seems that conda result not stable when resolving these packages.

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
