### PR TITLE
DOC: Update Xorbits build and installation process

### DIFF
--- a/doc/source/development/contributing_environment.rst
+++ b/doc/source/development/contributing_environment.rst
@@ -149,9 +149,10 @@ Step 4: build and install Xorbits
 You can now run::
 
    # Build and install Xorbits
-   python setup.py build_ext -i
-   python setup.py build_web
    python -m pip install -e ".[dev]"
+   python setup.py build_ext -i
+   # install nodejs  >= 14
+   python setup.py build_web
 
 At this point you should be able to import Xorbits from your locally built version::
 

--- a/doc/source/development/contributing_environment.rst
+++ b/doc/source/development/contributing_environment.rst
@@ -151,7 +151,6 @@ You can now run::
    # Build and install Xorbits
    python -m pip install -e ".[dev]"
    python setup.py build_ext -i
-   # install nodejs  >= 14
    python setup.py build_web
 
 At this point you should be able to import Xorbits from your locally built version::


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

1.Updated the Xorbits build and installation script. The command `python setup.py build_ext -i` may fail if the `xoscar` library is not installed. Running `python -m pip install -e ".[dev]"` first solves the problem.

2.The command `python setup.py build_web` requires Node version 14 or higher. 
## Related issue number

Fixes #492

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
