### PR TITLE
BUG: fix sort_index bug when level attribute is None

### DIFF
--- a/python/xorbits/_mars/dataframe/sort/sort_index.py
+++ b/python/xorbits/_mars/dataframe/sort/sort_index.py
@@ -225,7 +225,7 @@ def sort_index(
         raise TypeError(f"Invalid na_position: {na_position}")
     psrs_kinds = _validate_sort_psrs_kinds(psrs_kinds)
     axis = validate_axis(axis, a)
-    level = level if isinstance(level, (list, tuple)) else [level]
+    level = level if level is None or isinstance(level, (list, tuple)) else [level]
     op = DataFrameSortIndex(
         level=level,
         axis=axis,

--- a/python/xorbits/_mars/dataframe/sort/tests/test_sort_execution.py
+++ b/python/xorbits/_mars/dataframe/sort/tests/test_sort_execution.py
@@ -365,6 +365,16 @@ def test_sort_index_execution(setup):
     expected = raw.sort_index(ascending=False)
     pd.testing.assert_series_equal(result, expected)
 
+    # test multi-level DataFrame and level attribute is None in sort_index
+    raw = pd.DataFrame({"foo": np.random.randint(10, size=100), "bar": range(100)})
+    raw_gb_rolling_mean = raw.groupby(by="foo", group_keys=True).apply(
+        lambda x: x.rolling(window=10).mean()
+    )
+    mdf = DataFrame(raw_gb_rolling_mean)
+    result = mdf.sort_index().execute().fetch()
+    expected = raw_gb_rolling_mean.sort_index()
+    pd.testing.assert_frame_equal(result, expected)
+
 
 def test_arrow_string_sort_values(setup):
     rs = np.random.RandomState(0)


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

### backgroud
As shown in issue #391. Given a two-level multi-indexed dataframe, `sort_index` should firstly sort the dataframe by level 0. But in xorbits, the dataframe is firstly sorted by level 1.

```
import xorbits.pandas as pd
import xorbits.numpy as np

df = pd.DataFrame({"foo": np.random.randint(10, size=100), "bar": range(100)})
gb_rolling_mean = df.groupby(by="foo", group_keys=True).apply(lambda x: x.rolling(window=10).mean())
print(gb_rolling_mean.sort_index())
```

### analyse

In the `get_indexer_indexer` method of `pandas`, different methods are selected to calculate the indexer according to whether the level is `None`.
![image](https://github.com/xprobe-inc/xorbits/assets/26408901/d3e93c10-dfcd-486d-9b41-9c1c16eeb847)

However, in `xorbits` framework, if level is `None` (the default value is `None` when user doesn't set level), level will be updated to list(`[None]`) in `sort_index`, causing `pandas` doesn't take the branch of `level is None` when calculating the indexer. resulting in an error in the final result.


### fix
This PR fixes this bug. Keep level to `None` instead of updating to `[None]`.


<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes https://github.com/xprobe-inc/xorbits/issues/391

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
