### PR TITLE
BUG: fix `sort_index` bug of multi-level indexed Dataframe with multi-chunk

### DIFF
--- a/python/xorbits/_mars/dataframe/sort/sort_index.py
+++ b/python/xorbits/_mars/dataframe/sort/sort_index.py
@@ -225,13 +225,13 @@ def sort_index(
         raise TypeError(f"Invalid na_position: {na_position}")
     psrs_kinds = _validate_sort_psrs_kinds(psrs_kinds)
     axis = validate_axis(axis, a)
-    level = (
-        level
-        if level is None or isinstance(level, list)
-        else list(level)
-        if isinstance(level, tuple)
-        else [level]
-    )
+    # The API description does not mention that level can be of tuple
+    # type, but the behavior of level when it is a tuple is the same
+    # as that of a list. It is directly converted into a list here.
+    if isinstance(level, tuple):
+        level = list(level)
+    elif level is not None and not isinstance(level, list):
+        level = [level]
     op = DataFrameSortIndex(
         level=level,
         axis=axis,

--- a/python/xorbits/_mars/dataframe/sort/sort_index.py
+++ b/python/xorbits/_mars/dataframe/sort/sort_index.py
@@ -225,7 +225,13 @@ def sort_index(
         raise TypeError(f"Invalid na_position: {na_position}")
     psrs_kinds = _validate_sort_psrs_kinds(psrs_kinds)
     axis = validate_axis(axis, a)
-    level = level if level is None or isinstance(level, (list, tuple)) else [level]
+    level = (
+        level
+        if level is None or isinstance(level, list)
+        else list(level)
+        if isinstance(level, tuple)
+        else [level]
+    )
     op = DataFrameSortIndex(
         level=level,
         axis=axis,

--- a/python/xorbits/_mars/dataframe/sort/tests/test_sort_execution.py
+++ b/python/xorbits/_mars/dataframe/sort/tests/test_sort_execution.py
@@ -15,6 +15,7 @@
 
 import os
 import sys
+from itertools import product
 
 import numpy as np
 import pandas as pd
@@ -365,63 +366,68 @@ def test_sort_index_execution(setup):
     expected = raw.sort_index(ascending=False)
     pd.testing.assert_series_equal(result, expected)
 
-    # test multi-level DataFrame and level attribute is None in sort_index
-    raw = pd.DataFrame({"foo": np.random.randint(10, size=100), "bar": range(100)})
-    raw_gb_rolling_mean = raw.groupby(by="foo", group_keys=True).apply(
-        lambda x: x.rolling(window=10).mean()
-    )
-    mdf = DataFrame(raw_gb_rolling_mean)
-    result = mdf.sort_index().execute().fetch()
-    expected = raw_gb_rolling_mean.sort_index()
-    pd.testing.assert_frame_equal(result, expected)
 
-    # test multi-level DataFrame with multi-chunk
-    raw_index = pd.MultiIndex.from_arrays(np.random.randint(10, size=[4, 100]))
+@pytest.mark.parametrize(
+    "chunk_size, level, sort_remaining, ascending,",
+    list(
+        product(
+            [None, 20],
+            [
+                None,
+                (0,),
+                "index1",
+                2,
+                [0, 1],
+                ["index3", "index1"],
+                [3, 0, 1],
+                [2, "index1", 0],
+                ["index0", "index1", "index2", "index3"],
+                [2, 3, 1, 0],
+            ],
+            [True, False],
+            [True, False],
+        )
+    ),
+)
+def test_attributes_of_sort_index_execution(
+    chunk_size, level, sort_remaining, ascending, setup
+):
+    raw_index = pd.MultiIndex.from_arrays(
+        np.random.randint(10, size=[4, 100]),
+        names=["index0", "index1", "index2", "index3"],
+    )
     raw = pd.DataFrame(
         {"foo": np.random.randint(100, size=100), "bar": range(100)}, index=raw_index
     )
-    mdf = DataFrame(raw, chunk_size=20)
+    mdf = DataFrame(raw, chunk_size=chunk_size)
 
-    for level_ in [
-        None,
-        0,
-        2,
-        [3],
-        [0, 1],
-        [1, 0],
-        [3, 0, 1],
-        [0, 1, 2, 3],
-        [2, 3, 1, 0],
-    ]:
-        for sort_remaining_ in [True, False]:
-            for ascending_ in [True, False]:
-                result = (
-                    mdf.sort_index(
-                        level=level_,
-                        ascending=ascending_,
-                        sort_remaining=sort_remaining_,
-                    )
-                    .execute()
-                    .fetch()
+    result = (
+        mdf.sort_index(
+            level=level,
+            ascending=ascending,
+            sort_remaining=sort_remaining,
+        )
+        .execute()
+        .fetch()
+    )
+    expected = raw.sort_index(
+        level=level, ascending=ascending, sort_remaining=sort_remaining
+    )
+    # When index is not unique and there's multi chunk size, the sorting result may be inconsistent with pandas. Because PSRS is an unstable sort.
+    if level is not None and sort_remaining is False:
+        if isinstance(level, (list, tuple)):
+            for l in level:
+                pd.testing.assert_index_equal(
+                    result.index.get_level_values(l),
+                    expected.index.get_level_values(l),
                 )
-                expected = raw.sort_index(
-                    level=level_, ascending=ascending_, sort_remaining=sort_remaining_
-                )
-                # When index is not unique and there's multi chunk size, the sorting result may be inconsistent with pandas. Because PSRS is an unstable sort.
-                if level_ is not None and sort_remaining_ is False:
-                    if isinstance(level_, list):
-                        for l in level_:
-                            pd.testing.assert_index_equal(
-                                result.index.get_level_values(l),
-                                expected.index.get_level_values(l),
-                            )
-                    else:
-                        pd.testing.assert_index_equal(
-                            result.index.get_level_values(level_),
-                            expected.index.get_level_values(level_),
-                        )
-                else:
-                    pd.testing.assert_index_equal(result.index, expected.index)
+        else:
+            pd.testing.assert_index_equal(
+                result.index.get_level_values(level),
+                expected.index.get_level_values(level),
+            )
+    else:
+        pd.testing.assert_index_equal(result.index, expected.index)
 
 
 def test_arrow_string_sort_values(setup):

--- a/python/xorbits/_mars/dataframe/sort/tests/test_sort_execution.py
+++ b/python/xorbits/_mars/dataframe/sort/tests/test_sort_execution.py
@@ -375,6 +375,37 @@ def test_sort_index_execution(setup):
     expected = raw_gb_rolling_mean.sort_index()
     pd.testing.assert_frame_equal(result, expected)
 
+    # test multi-level DataFrame with multi-chunk
+    raw_index = pd.MultiIndex.from_arrays(np.random.randint(10, size=[2, 100]))
+    raw = pd.DataFrame(
+        {"foo": np.random.randint(100, size=100), "bar": range(100)}, index=raw_index
+    )
+    mdf = DataFrame(raw, chunk_size=20)
+
+    for level_ in [None, 0, 1, [0, 1], [1, 0]]:
+        for sort_remaining_ in [True, False]:
+            for ascending_ in [True, False]:
+                result = (
+                    mdf.sort_index(
+                        level=level_,
+                        ascending=ascending_,
+                        sort_remaining=sort_remaining_,
+                    )
+                    .execute()
+                    .fetch()
+                )
+                expected = raw.sort_index(
+                    level=level_, ascending=ascending_, sort_remaining=sort_remaining_
+                )
+                # When index is not unique and there's multi chunk size, the sorting result may be inconsistent with pandas. Because PSRS is an unstable sort.
+                if level_ in [0, 1] and sort_remaining_ is False:
+                    pd.testing.assert_index_equal(
+                        result.index.get_level_values(level_),
+                        expected.index.get_level_values(level_),
+                    )
+                else:
+                    pd.testing.assert_index_equal(result.index, expected.index)
+
 
 def test_arrow_string_sort_values(setup):
     rs = np.random.RandomState(0)


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

### backgroud
PR https://github.com/xprobe-inc/xorbits/pull/496 fixes add a unittest of `sort_index` without multi-chunk. This PR adds multi-chunk case in `sort_index` unittest.

However, after add `chunk_size` attribute while constructing DataFrame, the unittest gets an error in `searchsorted` method:
<img width="587" alt="image" src="https://github.com/xprobe-inc/xorbits/assets/26408901/24115903-67fd-4fd7-96a7-8dd960e9dbd4">

### analyse
When `sort_index` gets inputs of multi-level indexes, the input of `searchsorted` is MultiIndex.
However, `searchsorted` doesn't support MultiIndex or high-level dimension inputs.

### Fix
If inputs of `searchsorted` is MultiIndex, use `bisect` method to process it or transform it to single-Index according to `level` attribute.



<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
