### PR TITLE
DOC: Adds guide to use `-f` flag to modify default config.

### DIFF
--- a/doc/source/user_guide/deployment_cluster.rst
+++ b/doc/source/user_guide/deployment_cluster.rst
@@ -125,6 +125,30 @@ Extra Options for Workers
 |                    | devices                                                        |
 +--------------------+----------------------------------------------------------------+
 
+
+Custom configuration
+--------------------
+
+Default configuration can be modified by specifying a ``-f`` flag. Provide the path of your ``yml`` file which contains custom configuration along with ``-f`` flag.
+
+For example
+~~~~~~~~~~~
+
+If the user want to modify ``transfer_block_size``` and ``node_timeout``, specify ``-f your-config.yml``.
+
+your-config.yml
+
+.. code-block:: bash
+
+    "@inherits": "@default"
+    storage:
+    default_config: 
+        transfer_block_size: 10 * 1024 ** 2
+    cluster:
+    node_timeout: 1200
+
+
+
 Example
 -------
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->


## What do these changes do?
It is a guide with an example to override default config by using -f flag in documentation.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #454 

