### PR TITLE
FEAT: Support base Index_str method which won't change the index data-struc…

### DIFF
--- a/python/xorbits/_mars/dataframe/base/__init__.py
+++ b/python/xorbits/_mars/dataframe/base/__init__.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+from .accessor import IndexAccessor
 from .apply import df_apply, series_apply
 from .applymap import df_applymap
 from .astype import astype, index_astype
@@ -61,7 +61,7 @@ def _install():
     from .accessor import CachedAccessor, DatetimeAccessor, StringAccessor
     from .datetimes import _datetime_method_to_handlers
     from .standardize_range_index import ChunkStandardizeRangeIndex
-    from .string_ import _string_method_to_handlers
+    from .string_ import _index_method_to_handlers, _string_method_to_handlers
 
     for t in DATAFRAME_TYPE:
         setattr(t, "to_gpu", to_gpu)
@@ -149,9 +149,16 @@ def _install():
         if not hasattr(DatetimeAccessor, method):
             DatetimeAccessor._register(method)
 
+    for method in _index_method_to_handlers:
+        if not hasattr(IndexAccessor, method):
+            IndexAccessor._register(method)
+
     for series in SERIES_TYPE:
         series.str = CachedAccessor("str", StringAccessor)
         series.dt = CachedAccessor("dt", DatetimeAccessor)
+
+    for indexes in INDEX_TYPE:
+        indexes.str = CachedAccessor("str", IndexAccessor)
 
 
 _install()

--- a/python/xorbits/_mars/dataframe/base/accessor.py
+++ b/python/xorbits/_mars/dataframe/base/accessor.py
@@ -26,7 +26,41 @@ from pandas.api.types import (
 
 from ...utils import adapt_mars_docstring
 from .datetimes import SeriesDatetimeMethod, _datetime_method_to_handlers
-from .string_ import SeriesStringMethod, _string_method_to_handlers
+from .string_ import (
+    IndexStringMethod,
+    SeriesStringMethod,
+    _index_method_to_handlers,
+    _string_method_to_handlers,
+)
+
+
+class IndexAccessor:
+    def __init__(self, index):
+        self._index = index
+
+    @classmethod
+    def _gen_func(cls, method):
+        @wraps(getattr(pd.Index.str, method))
+        def _inner(self, *args, **kwargs):
+            op = IndexStringMethod(
+                method=method, method_args=args, method_kwargs=kwargs
+            )
+            return op(self._index)
+
+        _inner.__doc__ = adapt_mars_docstring(getattr(pd.Index.str, method).__doc__)
+        return _inner
+
+    def __getitem__(self, item):
+        return self._gen_func("__getitem__")(self, item)
+
+    def __dir__(self) -> Iterable[str]:
+        s = set(super().__dir__())
+        s.update(_index_method_to_handlers.keys())
+        return list(s)
+
+    @classmethod
+    def _register(cls, method):
+        setattr(cls, method, cls._gen_func(method))
 
 
 class StringAccessor:

--- a/python/xorbits/_mars/dataframe/core.py
+++ b/python/xorbits/_mars/dataframe/core.py
@@ -858,7 +858,7 @@ class _BatchedFetcher:
 
 
 class IndexData(HasShapeTileableData, _ToPandasMixin):
-    __slots__ = ()
+    __slots__ = "_cache", "_accessors"
     type_name = "Index"
 
     # optional field
@@ -898,6 +898,7 @@ class IndexData(HasShapeTileableData, _ToPandasMixin):
             _chunks=chunks,
             **kw,
         )
+        self._accessors = dict()
 
     @property
     def params(self) -> Dict[str, Any]:

--- a/python/xorbits/_mars/dataframe/utils.py
+++ b/python/xorbits/_mars/dataframe/utils.py
@@ -682,6 +682,28 @@ def build_df(df_obj, fill_value=1, size=1, ensure_string=False):
     return ret_df
 
 
+# by build a new series class, we can directly use pd.Index(Series) to turn it to Index Object.
+def build_empty_index(dtype, index=None, name=None, gpu: Optional[bool] = False):
+    xpd = cudf if gpu is True else pd
+    series_of_index = build_empty_series(dtype, index, name, gpu)
+    return xpd.Index(series_of_index)
+
+
+def build_index(
+    series_obj=None,
+    fill_value=1,
+    size=1,
+    name=None,
+    ensure_string=False,
+    dtype=None,
+    index=None,
+):
+    ret_series = build_series(
+        series_obj, fill_value, size, name, ensure_string, dtype, index
+    )
+    return pd.Index(ret_series)
+
+
 def build_empty_series(dtype, index=None, name=None, gpu: Optional[bool] = False):
     xpd = cudf if gpu is True else pd
     length = len(index) if index is not None else 0

--- a/python/xorbits/_mars/opcodes.py
+++ b/python/xorbits/_mars/opcodes.py
@@ -390,6 +390,7 @@ ALIGN = 741
 APPLYMAP = 742
 PIVOT = 743
 PIVOT_TABLE = 744
+INDEX_METHOD = 745  # new inserted operand name.
 
 FUSE = 801
 


### PR DESCRIPTION
…ture.

<!--
Thank you for your contribution!
-->

## What do these changes do?

These changes are intended to support the function of the Index.str framework similar to pandas.Index.str. Now the framework shall support the base method of Index.str such as Index. str. lower, upper, title, strip, count. Methods such as split or extract, which will modify the index structure, haven't been implemented yet but will soon come up. 

## Related issue number

Issues 441

## Check code requirements

- [1] tests added / passed (if needed)
- [1] Ensure all linting tests pass
