### PR TITLE
ENH: Make memory allocation more aggressive on local

### DIFF
--- a/python/xorbits/_mars/deploy/oscar/local.py
+++ b/python/xorbits/_mars/deploy/oscar/local.py
@@ -217,6 +217,11 @@ class LocalCluster:
             oscar_extra_conf=oscar_extra_conf,
         )
 
+        # modify scheduling config to make memory allocation policy
+        # more aggressive on local
+        if self._config.get("scheduling", {}).get("mem_hard_limit", None) is None:
+            self._config["scheduling"]["mem_hard_limit"] = None
+
         self._bands_to_resource = execution_config.get_deploy_band_resources()
         self._supervisor_pool = None
         self._worker_pools = []

--- a/python/xorbits/_mars/deploy/oscar/local.py
+++ b/python/xorbits/_mars/deploy/oscar/local.py
@@ -217,8 +217,8 @@ class LocalCluster:
             oscar_extra_conf=oscar_extra_conf,
         )
 
-        # modify scheduling config to make memory allocation policy
-        # more aggressive on local
+        # make memory allocation policy more aggressive on local by
+        # assuming all the memory are available.
         if self._config.get("scheduling", {}).get("mem_hard_limit", None) is None:
             self._config["scheduling"]["mem_hard_limit"] = None
 

--- a/python/xorbits/_mars/deploy/oscar/local.py
+++ b/python/xorbits/_mars/deploy/oscar/local.py
@@ -218,7 +218,7 @@ class LocalCluster:
         )
 
         # make memory allocation policy more aggressive on local by
-        # assuming all the memory are available.
+        # assuming all the memory is available.
         if self._config.get("scheduling", {}).get("mem_hard_limit", None) is None:
             self._config["scheduling"]["mem_hard_limit"] = None
 

--- a/python/xorbits/_mars/services/scheduling/worker/quota.py
+++ b/python/xorbits/_mars/services/scheduling/worker/quota.py
@@ -428,7 +428,7 @@ class WorkerQuotaManagerActor(mo.Actor):
                     QuotaActor,
                     band,
                     quota_size=band_config["quota_size"],
-                    uid=MemQuotaActor.gen_uid(band[1]),
+                    uid=QuotaActor.gen_uid(band[1]),
                     address=self.address,
                 )
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Set hard limit to None for local deployment so that `QuotaActor` won't check available memory when allocate memory, it will reduce false alarms about insufficient memory.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #503 

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
