### PR TITLE
BUG: fix dataframe sample

### DIFF
--- a/python/xorbits/_mars/dataframe/indexing/sample.py
+++ b/python/xorbits/_mars/dataframe/indexing/sample.py
@@ -407,6 +407,7 @@ class DataFrameSample(DataFrameOperand, DataFrameOperandMixin):
 
         if op.size is None:
             op._size = int(op.frac * in_df.shape[op.axis])
+            op._frac = None
 
         weights = op.weights
         if isinstance(weights, ENTITY_TYPE):

--- a/python/xorbits/_mars/dataframe/indexing/tests/test_indexing_execution.py
+++ b/python/xorbits/_mars/dataframe/indexing/tests/test_indexing_execution.py
@@ -1646,6 +1646,16 @@ def test_sample_execution(setup):
     r2 = df[:].sample(frac=0.1, weights=df["c2"], random_state=np.array([1, 2]))
     pd.testing.assert_frame_equal(r1.execute().fetch(), r2.execute().fetch())
 
+    # test parquet dataframe sample
+    with tempfile.TemporaryDirectory() as tempdir:
+        file_path = os.path.join(tempdir, "test.parquet")
+        raw_df.to_parquet(file_path)
+
+        df = md.read_parquet(file_path)
+        r1 = df.sample(frac=0.05, random_state=0)
+        r2 = pd.read_parquet(file_path).sample(frac=0.05, random_state=0)
+        pd.testing.assert_frame_equal(r1.execute().fetch(), r2)
+
     # test series
     raw_series = pd.Series(rs.rand(100))
     raw_weights = pd.Series(rs.rand(100))


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?
Set frac to None, when infer the size

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #529

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
