### PR TITLE
BUG: Fix password lost when calling `pd.read_sql`

### DIFF
--- a/python/xorbits/_mars/dataframe/datasource/read_sql.py
+++ b/python/xorbits/_mars/dataframe/datasource/read_sql.py
@@ -198,7 +198,7 @@ class DataFrameReadSQL(
         from sqlalchemy.sql import elements
 
         with create_sa_connection(self.con, **(self.engine_kwargs or dict())) as con:
-            self.con = str(con.engine.url)
+            self.con = con.engine.url.render_as_string(hide_password=False)
             selectable = self._get_selectable(con)
 
             # process index_col


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Use `url.render_as_string(hide_password=False)` instead of `str(url)` to keep password during serialization.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #xxxx

## Check code requirements

- [ ] tests added / passed (if needed)
- [ ] Ensure all linting tests pass
